### PR TITLE
add third party notices

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,36 @@
+# Third Party Notices
+
+The New Relic Ruby Security Agent uses source code from third party libraries which carry
+their own copyright notices and license terms. These notices are provided
+below.
+
+In the event that a required notice is missing or incorrect, please notify us
+by e-mailing [support@newrelic.com](mailto:support@newrelic.com).
+
+
+## [websocket-client-simple](https://rubygems.org/gems/websocket-client-simple)
+
+Copyright (c) 2013-2014 Sho Hashimoto
+
+Distributed under the following license(s):
+
+  * [The MIT License](http://opensource.org/licenses/MIT)
+
+
+## [event_emitter](https://rubygems.org/gems/event_emitter)
+
+Copyright (c) 2012 Sho Hashimoto
+
+Distributed under the following license(s):
+
+  * [The MIT License](http://opensource.org/licenses/MIT)
+
+
+## [websocket-ruby](https://rubygems.org/gems/websocket)
+
+Copyright © 2012 Bernard Potocki
+
+Distributed under the following license(s):
+
+  * [The MIT License](http://opensource.org/licenses/MIT)
+


### PR DESCRIPTION
Added third party notices file for following third party libraries:
- websocket-client-simple
- event_emitter
- websocket-ruby