### PR TITLE
Add Gemfile.lock to source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,60 @@
+PATH
+  remote: .
+  specs:
+    newrelic_security (0.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    docile (1.4.0)
+    json (2.6.3)
+    minitest (5.20.0)
+    parallel (1.23.0)
+    parser (3.2.2.4)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    rake (12.3.3)
+    regexp_parser (2.8.2)
+    rexml (3.2.6)
+    rubocop (1.49.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-minitest (0.33.0)
+      rubocop (>= 1.39, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  minitest (~> 5.18)
+  newrelic_security!
+  rake (~> 12.0)
+  rubocop (~> 1.49.0)
+  rubocop-minitest (~> 0.29)
+  rubocop-rake (~> 0.6)
+  simplecov (~> 0.22)
+
+BUNDLED WITH
+   2.2.27


### PR DESCRIPTION
A gemfile.lock is required for dependency scanning tools to accurately scan repositories for vulnerabilities and licenses. Please consider adding a gemfile.lock to source.