### PR TITLE
fix for Absolute file path is not found in parameters in file events

### DIFF
--- a/lib/newrelic_security/agent/control/collector.rb
+++ b/lib/newrelic_security/agent/control/collector.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'digest'
+require 'pathname'
 
 module NewRelic::Security
   module Agent
@@ -18,7 +19,7 @@ module NewRelic::Security
         def collect(case_type, args, event_category = nil, **keyword_args)
           return unless NewRelic::Security::Agent.config[:enabled]
           return if NewRelic::Security::Agent::Control::HTTPContext.get_context.nil?
-          
+          args.map! { |file| Pathname.new(file).relative? ? File.join(Dir.pwd, file) : file } if [FILE_OPERATION, FILE_INTEGRITY].include?(case_type)
           event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
 
           stk = caller_locations[1..COVERAGE]

--- a/lib/newrelic_security/agent/utils/agent_utils.rb
+++ b/lib/newrelic_security/agent/utils/agent_utils.rb
@@ -31,7 +31,7 @@ module NewRelic::Security
             while i < fuzz_request.length()
                 begin
                   fuzz_request[i].gsub!(NR_CSEC_VALIDATOR_HOME_TMP, NR_SECURITY_HOME_TMP)
-                  fuzz_request.gsub!(NR_CSEC_VALIDATOR_FILE_SEPARATOR, ::File::SEPARATOR)
+                  fuzz_request[i].gsub!(NR_CSEC_VALIDATOR_FILE_SEPARATOR, ::File::SEPARATOR)
                   dirname = ::File.dirname(fuzz_request[i])
                   ::FileUtils.mkdir_p(dirname, :mode => 0666) unless ::File.directory?(dirname)
                   ::File.open(fuzz_request[i], ::File::WRONLY | ::File::CREAT | ::File::EXCL) do |fd|


### PR DESCRIPTION
fix for Absolute file path is not found in parameters in file events