### PR TITLE
test-arch-update

### DIFF
--- a/lib/newrelic_security/instrumentation-security/async-http/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/async-http/chain.rb
@@ -10,7 +10,7 @@ module NewRelic::Security
   
             def call(method, url, headers = nil, body = nil)
               retval = nil
-              event = call_on_enter(method, url, headers = nil, body = nil) { retval = call_without_security(method, url, headers, body) }
+              event = call_on_enter(method, url, headers, body) { retval = call_without_security(method, url, headers, body) }
               call_on_exit(event) { return retval }
             end
           end

--- a/lib/newrelic_security/instrumentation-security/ethon/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/ethon/instrumentation.rb
@@ -91,7 +91,7 @@ module NewRelic::Security
           easy_handles.each do |easy|
             context = NewRelic::Security::Agent::Control::HTTPContext.get_context.cache[easy.object_id] if NewRelic::Security::Agent::Control::HTTPContext.get_context
             headers_copy = {}
-            headers_copy.merge!(context[:headers]) if context.key?(:headers)
+            headers_copy.merge!(context[:headers]) if context&.key?(:headers)
             NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(headers_copy, event) if event
             easy.headers = headers_copy
           end

--- a/lib/newrelic_security/instrumentation-security/net_ldap/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/net_ldap/chain.rb
@@ -8,9 +8,9 @@ module NewRelic::Security
 
             alias_method :search_without_security, :search
   
-            def search(args = {})
+            def search(args = {}, &block)
               retval = nil
-              event = search_on_enter(args) { retval = search_without_security(args) }
+              event = search_on_enter(args) { retval = search_without_security(args, &block) }
               search_on_exit(event) { return retval }
             end
           end

--- a/lib/newrelic_security/instrumentation-security/net_ldap/prepend.rb
+++ b/lib/newrelic_security/instrumentation-security/net_ldap/prepend.rb
@@ -4,7 +4,7 @@ module NewRelic::Security
       module Prepend
         include NewRelic::Security::Instrumentation::NetLDAP
 
-        def search(args = {})
+        def search(args = {}, &block)
           retval = nil
           event = search_on_enter(args) { retval = super }
           search_on_exit(event) { return retval }

--- a/lib/newrelic_security/instrumentation-security/sqlite3/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/sqlite3/chain.rb
@@ -16,14 +16,6 @@ module NewRelic::Security
                 execute_on_exit(event) { return retval }
               end
 
-              alias_method :execute2_without_security, :execute2
-    
-              def execute2(sql, *bind_vars)
-                retval = nil
-                event = execute2_on_enter(sql, *bind_vars) { retval = execute2_without_security(sql, *bind_vars) }
-                execute2_on_exit(event) { return retval }
-              end
-
               alias_method :execute_batch_without_security, :execute_batch
     
               def execute_batch(sql, bind_vars = [], *args)
@@ -39,14 +31,6 @@ module NewRelic::Security
                 event = execute_batch2_on_enter(sql) { retval = execute_batch2_without_security(sql, &block) }
                 execute_batch2_on_exit(event) { return retval }
               end
-
-              alias_method :prepare_without_security, :prepare
-    
-              def prepare(sql)
-                retval = nil
-                event = prepare_on_enter(sql) { retval = prepare_without_security(sql) }
-                prepare_on_exit(event, retval, sql) { return retval }
-              end
               
             end
           end
@@ -59,6 +43,14 @@ module NewRelic::Security
           def self.instrument!
             ::SQLite3::Statement.class_eval do
               include NewRelic::Security::Instrumentation::SQLite3::Statement
+
+              alias_method :initialize_without_security, :initialize
+    
+              def initialize(db, sql)
+                retval = nil
+                event = initialize_on_enter(db, sql) { retval = initialize_without_security(db, sql) }
+                initialize_on_exit(event, retval, sql) { return retval }
+              end
 
               alias_method :bind_params_without_security, :bind_params
 

--- a/lib/newrelic_security/instrumentation-security/sqlite3/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/sqlite3/instrumentation.rb
@@ -154,7 +154,7 @@ module NewRelic::Security
             ic_args.push(hash)
           end
         end
-        if ic_args[0].has_key?(:sql)
+        if ic_args[0]&.has_key?(:sql)
           event = NewRelic::Security::Agent::Control::Collector.collect(SQL_DB_COMMAND, ic_args, SQLITE) unless NewRelic::Security::Instrumentation::InstrumentationUtils.sql_filter_events?(ic_args[0][:sql])
         else
           event = NewRelic::Security::Agent::Control::Collector.collect(SQL_DB_COMMAND, ic_args, SQLITE)

--- a/lib/newrelic_security/instrumentation-security/sqlite3/prepend.rb
+++ b/lib/newrelic_security/instrumentation-security/sqlite3/prepend.rb
@@ -11,12 +11,6 @@ module NewRelic::Security
             execute_on_exit(event) { return retval }
           end
 
-          def execute2(sql, *bind_vars)
-            retval = nil
-            event = execute2_on_enter(sql, *bind_vars) { retval = super }
-            execute2_on_exit(event) { return retval }
-          end
-
           def execute_batch(sql, bind_vars = [], *args)
             retval = nil
             event = execute_batch_on_enter(sql, bind_vars, *args) { retval = super }
@@ -29,18 +23,18 @@ module NewRelic::Security
             execute_batch2_on_exit(event) { return retval }
           end
 
-          def prepare(sql)
-            retval = nil
-            event = prepare_on_enter(sql) { retval = super }
-            prepare_on_exit(event, retval, sql) { return retval }
-          end
-
         end
       end
 
       module Statement
         module Prepend
           include NewRelic::Security::Instrumentation::SQLite3::Statement
+
+          def initialize(db, sql)
+            retval = nil
+            event = initialize_on_enter(db, sql) { retval = super }
+            initialize_on_exit(event, retval, sql) { return retval }
+          end
           
           def bind_params(*bind_vars)
             retval = nil

--- a/lib/newrelic_security/instrumentation-security/typhoeus/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/typhoeus/instrumentation.rb
@@ -67,3 +67,4 @@ end
 
 # NewRelic::Security::Instrumentation::InstrumentationLoader.install_instrumentation(:typhoeus, ::Typhoeus::Request, ::NewRelic::Security::Instrumentation::Typhoeus::Request)
 # NewRelic::Security::Instrumentation::InstrumentationLoader.install_instrumentation(:typhoeus, ::Typhoeus::Hydra, ::NewRelic::Security::Instrumentation::Typhoeus::Hydra)
+# TODO: Remove typhoeus instrumentation files, as this is Ethon based client. Ethon instrumentation is already supported.

--- a/lib/newrelic_security/instrumentation-security/typhoeus/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/typhoeus/instrumentation.rb
@@ -65,5 +65,5 @@ module NewRelic::Security
   end
 end
 
-NewRelic::Security::Instrumentation::InstrumentationLoader.install_instrumentation(:typhoeus, ::Typhoeus::Request, ::NewRelic::Security::Instrumentation::Typhoeus::Request)
-NewRelic::Security::Instrumentation::InstrumentationLoader.install_instrumentation(:typhoeus, ::Typhoeus::Hydra, ::NewRelic::Security::Instrumentation::Typhoeus::Hydra)
+# NewRelic::Security::Instrumentation::InstrumentationLoader.install_instrumentation(:typhoeus, ::Typhoeus::Request, ::NewRelic::Security::Instrumentation::Typhoeus::Request)
+# NewRelic::Security::Instrumentation::InstrumentationLoader.install_instrumentation(:typhoeus, ::Typhoeus::Hydra, ::NewRelic::Security::Instrumentation::Typhoeus::Hydra)

--- a/test/helpers/database_helper.rb
+++ b/test/helpers/database_helper.rb
@@ -1,0 +1,113 @@
+require 'docker'
+
+module NewRelic::Security
+  module Test
+    MYSQL_HOST = '127.0.0.1'
+    MYSQL_PORT = 3307
+    MYSQL_USERNAME = 'root'
+    MYSQL_PASSWORD = ''
+    MYSQL_DATABASE = 'testdb'
+
+    MONGODB_URL = 'localhost:27018'
+    MONGODB_DATABASE = 'testdb'
+
+    POSTGRESQL_HOST = 'localhost'
+    POSTGRESQL_PORT = '5433'
+    POSTGRESQL_USER = 'postgres'
+    POSTGRESQL_DATABASE = 'postgres'
+
+    module DatabaseHelper
+      extend self
+
+      MYSQL_CONFIG = {
+        'Image' => 'mysql:latest',
+        'name' => 'mysql_test',
+        'Env' => ['MYSQL_ALLOW_EMPTY_PASSWORD=yes', 'MYSQL_USER=test', 'MYSQL_DATABASE=testdb'],
+        'HostConfig' => {
+          'PortBindings' => {
+            '3306/tcp' => [{ 'HostPort' => MYSQL_PORT.to_s }]
+          }
+        }
+      }
+
+      def create_mysql_container
+        image = Docker::Image.create('fromImage' => 'mysql:latest')
+        image.refresh!
+        begin
+            Docker::Container.get('mysql_test').remove(force: true)
+        rescue
+        end
+        container = Docker::Container.create(MYSQL_CONFIG)
+        container.start
+        sleep 15
+      end
+
+      def remove_mysql_container
+        begin
+          Docker::Container.get('mysql_test').remove(force: true)
+        rescue 
+        end
+      end
+
+      MONGO_CONFIG = {
+        'Image' => 'mongo:latest',
+        'name' => 'mongo_test',
+        'HostConfig' => {
+          'PortBindings' => {
+              '27017/tcp' => [{ 'HostPort' => '27018' }]
+          }
+        }
+      }
+
+      def create_mongodb_container
+        image = Docker::Image.create('fromImage' => 'mongo:latest')
+        image.refresh!
+        begin
+            Docker::Container.get('mongo_test').remove(force: true)
+        rescue
+        end
+        container = Docker::Container.create(MONGO_CONFIG)
+        container.start
+        sleep 5
+      end
+
+      def remove_mongodb_container
+        begin
+          Docker::Container.get('mongo_test').remove(force: true)
+        rescue
+        end
+      end
+
+      POSTGRESQL_CONFIG = {
+            'Image' => 'postgres:latest',
+            'name' => 'pg_test',
+            'Env' => ['POSTGRES_HOST_AUTH_METHOD=trust'],
+            'HostConfig' => {
+                'PortBindings' => {
+                '5432/tcp' => [{ 'HostPort' => POSTGRESQL_PORT }]
+                }
+            }
+        }
+
+      def create_postgresql_container
+        image = Docker::Image.create('fromImage' => 'postgres:latest')
+        image.refresh!
+        begin
+            Docker::Container.get('pg_test').remove(force: true)
+        rescue
+        end
+        container = Docker::Container.create(POSTGRESQL_CONFIG)
+        container.start
+        sleep 5
+      end
+
+      def remove_postgresql_container
+        begin
+          Docker::Container.get('pg_test').remove(force: true)
+        rescue
+        end
+      end
+
+    end
+  end
+end

--- a/test/helpers/event_helper.rb
+++ b/test/helpers/event_helper.rb
@@ -6,15 +6,16 @@ module NewRelic::Security
         def collect(case_type, args, event_category = nil, **keyword_args)
           event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
           $event_list.push(event)
-          return false
+          false
         end
         
         def get_event_count(caseType)
-          event_count = 0
-          for event in $event_list
-            event_count += 1 if event.caseType == caseType
-          end
-          return event_count
+          filter_events(caseType)
+          $event_list.size
+        end
+
+        def filter_events(caseType)
+          $event_list.reject! { |event| event if event.caseType != caseType }
         end
       end
     end

--- a/test/helpers/sample_server.rb
+++ b/test/helpers/sample_server.rb
@@ -1,45 +1,49 @@
 require 'rack'
 require 'json'
 
-class SampleServer < Rack::Builder
-  def self.call(env)
-    case env['REQUEST_METHOD']
-    when 'GET'
-      get_books(env)
-    when 'POST'
-      create_book(env)
-    when 'PUT'
-      update_book(env)
-    when 'DELETE'
-      delete_book(env)
-    else
-       [404, {'Content-Type' =>  'text/plain'}, ['Not']]
+module NewRelic::Security
+  module Test
+    class SampleServer < Rack::Builder
+      def self.call(env)
+        case env['REQUEST_METHOD']
+        when 'GET'
+          get_books(env)
+        when 'POST'
+          create_book(env)
+        when 'PUT'
+          update_book(env)
+        when 'DELETE'
+          delete_book(env)
+        else
+          [404, {'Content-Type' =>  'text/plain'}, ['Not']]
+        end
+      end
+
+      def self.get_books(env)
+        # Return a list of books in JSON format
+        [200, {'Content-Type' => 'application/json'}, [{id: 1, title: 'Book 1', author: 'Author 1'}].to_json]
+      end
+
+      def self.create_book(env)
+        # Create a new book from the request body
+        book = JSON.parse(env['rack.input'].read)
+        # Simulate creating a new book in a database
+        [201, {'Content-Type' => 'application/json'}, [{id: 2, title: book['title'], author: book['author']}.to_json]]
+      end
+
+      def self.update_book(env)
+        # Update an existing book from the request body
+        book = JSON.parse(env['rack.input'].read)
+        # Simulate updating a book in a database
+        [200, {'Content-Type' => 'application/json'}, [{id: 1, title: book['title'], author: book['author']}.to_json]]
+      end
+
+      def self.delete_book(env)
+        # Delete an existing book
+        # Simulate deleting a book from a database
+        [204, {'Content-Type' => 'text/plain'}, ['Book deleted']]
+      end
     end
-  end
-
-  def self.get_books(env)
-     # Return a list of books in JSON format
-     [200, {'Content-Type' => 'application/json'}, [{id: 1, title: 'Book 1', author: 'Author 1'}].to_json]
-  end
-
-  def self.create_book(env)
-     # Create a new book from the request body
-    book = JSON.parse(env['rack.input'].read)
-     # Simulate creating a new book in a database
-     [201, {'Content-Type' => 'application/json'}, [{id: 2, title: book['title'], author: book['author']}.to_json]]
-  end
-
-  def self.update_book(env)
-     # Update an existing book from the request body
-    book = JSON.parse(env['rack.input'].read)
-     # Simulate updating a book in a database
-     [200, {'Content-Type' => 'application/json'}, [{id: 1, title: book['title'], author: book['author']}.to_json]]
-  end
-
-  def self.delete_book(env)
-     # Delete an existing book
-     # Simulate deleting a book from a database
-     [204, {'Content-Type' => 'text/plain'}, ['Book deleted']]
   end
 end
 

--- a/test/newrelic_security/instrumentation-security/active_record/postgresql_adapter/postgresql_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/postgresql_adapter/postgresql_adapter_test.rb
@@ -1,5 +1,4 @@
 require 'rails'
-require 'pg'
 require 'active_record'
 require "active_record/connection_adapters/postgresql_adapter"
 require_relative '../../../../test_helper'

--- a/test/newrelic_security/instrumentation-security/active_record/postgresql_adapter/postgresql_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/postgresql_adapter/postgresql_adapter_test.rb
@@ -94,7 +94,7 @@ module NewRelic::Security
                     expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, POSTGRES)
                     expected_sql_list = args1[0][:sql].split(" ")
                     puts "$event_list : #{$event_list.inspect}"
-                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
+                    assert_equal 3, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     sql_fetch_list1 = $event_list[0].parameters[0][:sql].split(" ")
                     assert_equal expected_event1.caseType, $event_list[0].caseType
                     assert_equal expected_sql_list, sql_fetch_list1

--- a/test/newrelic_security/instrumentation-security/active_record/postgresql_adapter/postgresql_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/postgresql_adapter/postgresql_adapter_test.rb
@@ -2,19 +2,15 @@ require 'rails'
 require 'pg'
 require 'docker'
 require 'active_record'
+require "active_record/connection_adapters/postgresql_adapter"
 require_relative '../../../../test_helper'
-require 'newrelic_security/instrumentation-security/pg/instrumentation'
+require 'newrelic_security/instrumentation-security/active_record/postgresql_adapter/instrumentation'
 
 class NewUser < ActiveRecord::Base
 end
 
-image = Docker::Image.create('fromImage' => 'postgres:latest')
-image.refresh!
-
 # test setup
 $test_file_path = __dir__ 
-ActiveRecord::Base.establish_connection adapter: 'postgresql', database: 'postgres', :port => 5433, :host => 'localhost', :user => 'postgres'
-require 'newrelic_security/instrumentation-security//active_record/postgresql_adapter/instrumentation'
 
 module NewRelic::Security
     module Test

--- a/test/newrelic_security/instrumentation-security/active_record/sqlite3_adapter/sqlite3_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/sqlite3_adapter/sqlite3_adapter_test.rb
@@ -8,10 +8,9 @@ class FakeUser < ActiveRecord::Base
 end
 
 # test setup
-test_file_path = __dir__ 
-$database_name = test_file_path + "/db/test.db"
+$database_name = __dir__ + "/db/test.db"
 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: $database_name
-load  test_file_path +'/db/schema.rb'
+load  "#{__dir__}/db/schema.rb"
 
 require 'newrelic_security/instrumentation-security//active_record/sqlite3_adapter/instrumentation'
 
@@ -31,7 +30,7 @@ module NewRelic::Security
 
                     # INSERT test
                     if RUBY_VERSION < '2.5.0'
-                        user = FakeUser.create(id: 1, email: 'me@john.com', name: 'John', ssn: '11')
+                        FakeUser.create(id: 1, email: 'me@john.com', name: 'John', ssn: '11')
                         # 4 event verify 
                         args1 = [{:sql=>"            SELECT sql FROM\n              (SELECT * FROM sqlite_master UNION ALL\n               SELECT * FROM sqlite_temp_master)\n            WHERE type = 'table' AND name = 'fake_users'\n", :parameters=>[]}]
                         args2 = [{:sql=>"SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND type IN ('table','view')", :parameters=>[]}]

--- a/test/newrelic_security/instrumentation-security/active_record/sqlite3_adapter/sqlite3_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/sqlite3_adapter/sqlite3_adapter_test.rb
@@ -22,6 +22,10 @@ module NewRelic::Security
                 @@case_type = "SQL_DB_COMMAND"
                 @@event_category = "SQLITE"
 
+                def setup
+                    NewRelic::Security::Agent::Control::HTTPContext.set_context({})
+                end
+
                 def test_exec_query 
                     ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: $database_name
                     FakeUser.delete_all
@@ -142,6 +146,10 @@ module NewRelic::Security
                     assert_equal expected_event1.eventCategory, $event_list[0].eventCategory  
                     ActiveRecord::Base.remove_connection
                     $event_list.clear()
+                end
+
+                def teardown
+                    NewRelic::Security::Agent::Control::HTTPContext.reset_context
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/active_record/sqlite3_adapter/sqlite3_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/sqlite3_adapter/sqlite3_adapter_test.rb
@@ -19,8 +19,6 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestSQLite3Adapter < Minitest::Test
-                @@case_type = "SQL_DB_COMMAND"
-                @@event_category = "SQLITE"
 
                 def setup
                     NewRelic::Security::Agent::Control::HTTPContext.set_context({})
@@ -38,10 +36,10 @@ module NewRelic::Security
                         args1 = [{:sql=>"            SELECT sql FROM\n              (SELECT * FROM sqlite_master UNION ALL\n               SELECT * FROM sqlite_temp_master)\n            WHERE type = 'table' AND name = 'fake_users'\n", :parameters=>[]}]
                         args2 = [{:sql=>"SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND type IN ('table','view')", :parameters=>[]}]
                         args3 = [{:sql=>"INSERT INTO \"fake_users\" (\"id\", \"name\", \"email\", \"ssn\") VALUES (?, ?, ?, ?)", :parameters=>["1", "John", "me@john.com", "11"]}]         
-                        expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                        expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                        expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
-                        assert_equal 4, $event_list.length
+                        expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                        expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                        expected_event3 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args3, SQLITE)
+                        assert_equal 4, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                         # sqlite_master
                         assert_equal expected_event1.caseType, $event_list[0].caseType
                         assert_equal expected_event1.parameters, $event_list[0].parameters
@@ -69,10 +67,10 @@ module NewRelic::Security
                         args1 = [{:sql=>"SELECT sqlite_version(*)", :parameters=>[]}]
                         args2 = [{:sql=>"SELECT sql FROM\n  (SELECT * FROM sqlite_master UNION ALL\n   SELECT * FROM sqlite_temp_master)\nWHERE type = 'table' AND name = 'fake_users'\n", :parameters=>[]}]
                         args3 = [{:sql=>"INSERT INTO \"fake_users\" (\"id\",\"email\",\"name\",\"ssn\") VALUES (1, 'me@john.com', 'John', '11') ON CONFLICT  DO NOTHING", :parameters=>[]}]         
-                        expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                        expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                        expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
-                        assert_equal 3, $event_list.length
+                        expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                        expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                        expected_event3 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args3, SQLITE)
+                        assert_equal 3, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                         # sqlite_version
                         assert_equal expected_event1.caseType, $event_list[0].caseType
                         assert_equal expected_event1.parameters, $event_list[0].parameters
@@ -97,8 +95,8 @@ module NewRelic::Security
                     assert_equal "11", output.ssn
                     # event verify
                     args1 = [{:sql=>"SELECT \"fake_users\".* FROM \"fake_users\" WHERE \"fake_users\".\"id\" = ? LIMIT ?", :parameters=>["1", "1"]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     expected_sql_list = args1[0][:sql].split(" ")
                     sql_fetch_list = $event_list[0].parameters[0][:sql].split(" ")
                     assert_equal expected_event1.caseType, $event_list[0].caseType
@@ -117,9 +115,9 @@ module NewRelic::Security
                     # event verify
                     args1 = [{:sql=>"SELECT \"fake_users\".* FROM \"fake_users\" WHERE \"fake_users\".\"id\" = ? LIMIT ?", :parameters=>["1", "1"]}]
                     args2 = [{:sql=>"UPDATE \"fake_users\" SET \"name\" = ? WHERE \"fake_users\".\"id\" = ?", :parameters=>["Jack", "1"]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     # select event
                     expected_sql_list = args1[0][:sql].split(" ")
                     sql_fetch_list = $event_list[0].parameters[0][:sql].split(" ")
@@ -139,8 +137,8 @@ module NewRelic::Security
                     assert_equal 1, output
                     # event verify
                     args1 = [{:sql=>"DELETE FROM \"fake_users\" WHERE \"fake_users\".\"id\" = ?", :parameters=>["1"]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event1.caseType, $event_list[0].caseType
                     assert_equal expected_event1.parameters, $event_list[0].parameters
                     assert_equal expected_event1.eventCategory, $event_list[0].eventCategory  

--- a/test/newrelic_security/instrumentation-security/async-http/async_http_test.rb
+++ b/test/newrelic_security/instrumentation-security/async-http/async_http_test.rb
@@ -8,9 +8,11 @@ module NewRelic::Security
         module Instrumentation
             class TestAsyncHTTP < Minitest::Test
 
-                def test_get
+                def setup
                     $event_list.clear()
-                    url = "http://www.google.com"
+                end
+
+                def test_get
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com/search?q=test", :path=>"/search", :query=>"q=test", :Body=>"", :Headers=>{"accept"=>"application/json"}}]
                     response = nil
                     Async do
@@ -35,20 +37,17 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 if RUBY_VERSION >= '2.5.0'
                     def test_get_ssl
-                        $event_list.clear()
-                        url = "http://www.google.com"
                         args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/search?q=test", :path=>"/search", :query=>"q=test", :Body=>"", :Headers=>{"accept"=>"application/json"}}]
                         response = nil
                         Async do
                             begin
                                 internet = Async::HTTP::Internet.new
-                                headers = [['accept', 'application/json']]
-                                response = internet.get "https://www.google.com/search?q=test"#, headers
+                                response = internet.get "https://www.google.com/search?q=test"
                                 response.read
                             rescue Exception => e
                                 NewRelic::Security::Agent.logger.debug "Exception in TestAsyncHTTP.test_get_ssl : #{e} #{e.backtrace}"
@@ -65,12 +64,11 @@ module NewRelic::Security
                         assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                         assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                         assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                        assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                        assert_nil $event_list[0].eventCategory
                     end
                 end
 
                 def test_post_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books"
                     args = [{:Method=>"POST", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
                     data = {"title"=>"New", "author"=>"New Author"}
@@ -97,11 +95,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>"PUT", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
                     data = {"title"=>"Update Book","author"=>"Update Author"}
@@ -128,11 +125,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>"DELETE", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
                     response = nil
@@ -156,7 +152,7 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/curb/curb_test.rb
+++ b/test/newrelic_security/instrumentation-security/curb/curb_test.rb
@@ -6,24 +6,24 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestCurb < Minitest::Test
-                @@url = "https://www.google.com"
-                @@case_type = "HTTP_REQUEST"
-                @@event_category = nil
-                @@args = [{:Method=>nil, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                TEST_URL = "https://www.google.com"
+                ARGS = [{:Method=>nil, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+
+                def setup
+                    $event_list.clear()
+                end
 
                 def test_curl 
-                    $event_list.clear()
-                    @output = Curl.get(@@url).url
+                    @output = Curl.get(TEST_URL).url
                     assert_equal "https://www.google.com", @output  
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, ARGS, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory  
+                    assert_nil $event_list[0].eventCategory  
                 end
 
                 def test_curl_multi_perform
-                    $event_list.clear()
                     responses = {}
                     requests = ["https://www.google.com"]
                     m = Curl::Multi.new
@@ -41,39 +41,37 @@ module NewRelic::Security
                         #puts "idling... can do some work here"
                     end
                     assert_equal 200, @output  
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, ARGS, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_curl_multi_get
-                    $event_list.clear()
                     easy_options = {:follow_location => true}
                     multi_options = {}
-                    Curl::Multi.get([@@url], easy_options, multi_options) do|easy|
+                    Curl::Multi.get([TEST_URL], easy_options, multi_options) do|easy|
                         # do something interesting with the easy response
                         @output= easy.code
                     end
                     assert_equal 200, @output  
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, ARGS, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_curl_easy_perform
-                    $event_list.clear()
-                    response = Curl::Easy.perform(@@url)
+                    response = Curl::Easy.perform(TEST_URL)
                     @output = response.code
                     assert_equal 200, @output  
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, ARGS, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
             end
         end

--- a/test/newrelic_security/instrumentation-security/dir/dir_test.rb
+++ b/test/newrelic_security/instrumentation-security/dir/dir_test.rb
@@ -5,91 +5,85 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestDir < Minitest::Test
-                @@temp_dir = $test_path + "/resources/tmp"
-                @@case_type = "FILE_OPERATION"
-                @@args = [@@temp_dir]
-                @@event_category = nil
+                TMP_DIR = $test_path + "/resources/tmp"
+                TEMP_DIR = $test_path + "/resources/temp"
 
                 def test_mkdir_rmdir_file_operation
                     # mkdir test
-                    FileUtils.remove_dir(@@temp_dir) if Dir.exist?(@@temp_dir)
+                    FileUtils.remove_dir(TMP_DIR) if Dir.exist?(TMP_DIR)
                     $event_list.clear()
-                    output = Dir.mkdir(@@temp_dir)
+                    output = Dir.mkdir(TMP_DIR)
                     assert_equal 0, output
                     # event verify
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [TMP_DIR], WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     
                     # rmdir test
                     $event_list.clear()
-                    output = Dir.rmdir(@@temp_dir)
+                    output = Dir.rmdir(TMP_DIR)
                     assert_equal 0, output
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [TMP_DIR], DELETE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_mkdir_rmdir_file_integrity
-                    temp_dir = $test_path + "/resources/temp"
-                    FileUtils.remove_dir(temp_dir) if Dir.exist?(temp_dir)
+                    FileUtils.remove_dir(TEMP_DIR) if Dir.exist?(TEMP_DIR)
                     $event_list.clear()
                     
                     # mkdir test
-                    output = Dir.mkdir(temp_dir)
+                    output = Dir.mkdir(TEMP_DIR)
                     assert_equal 0, output
                     # event verify
-                    case_type = "FILE_INTEGRITY"
-                    args = [temp_dir]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_INTEGRITY, [TEMP_DIR], WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_INTEGRITY)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     
                     # rmdir test
                     $event_list.clear()
-                    output = Dir.rmdir(temp_dir)
+                    output = Dir.rmdir(TEMP_DIR)
                     assert_equal 0, output
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_INTEGRITY, [TEMP_DIR], DELETE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_INTEGRITY)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_unlink_file_operation
                     # unlink test
-                    FileUtils.remove_dir(@@temp_dir) if Dir.exist?(@@temp_dir)
+                    FileUtils.remove_dir(TMP_DIR) if Dir.exist?(TMP_DIR)
                     $event_list.clear()
-                    Dir.mkdir(@@temp_dir)
-                    output = Dir.unlink(@@temp_dir)
+                    Dir.mkdir(TMP_DIR)
+                    output = Dir.unlink(TMP_DIR)
                     assert_equal 0, output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [TMP_DIR], DELETE)
+                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[1].caseType
                     assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[1].eventCategory
                 end
 
                 def test_unlink_file_integrity
-                    temp_dir = $test_path + "/resources/temp"
-                    FileUtils.remove_dir(temp_dir) if Dir.exist?(temp_dir)
-                    Dir.mkdir(temp_dir)
+                    FileUtils.remove_dir(TEMP_DIR) if Dir.exist?(TEMP_DIR)
+                    Dir.mkdir(TEMP_DIR)
                     $event_list.clear()
                     # unlink test
-                    output = Dir.unlink(temp_dir)
+                    output = Dir.unlink(TEMP_DIR)
                     assert_equal 0, output
                     # event verify
-                    case_type = "FILE_INTEGRITY"
-                    args = [temp_dir]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_INTEGRITY, [TEMP_DIR], DELETE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_INTEGRITY)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
             end
         end

--- a/test/newrelic_security/instrumentation-security/dir/dir_test.rb
+++ b/test/newrelic_security/instrumentation-security/dir/dir_test.rb
@@ -5,8 +5,8 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestDir < Minitest::Test
-                TMP_DIR = $test_path + "/resources/tmp"
-                TEMP_DIR = $test_path + "/resources/temp"
+                TMP_DIR = TEST_PATH + "/resources/tmp"
+                TEMP_DIR = TEST_PATH + "/resources/temp"
 
                 def test_mkdir_rmdir_file_operation
                     # mkdir test

--- a/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
+++ b/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
@@ -8,11 +8,11 @@ module NewRelic::Security
             class TestEthonEasy < Minitest::Test
 
                 def setup
+                    $event_list.clear()
                     NewRelic::Security::Agent::Control::HTTPContext.set_context({})
                 end
 
                 def test_get
-                    $event_list.clear()
                     url = "http://www.google.com"
                     args = [{:scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil}]
                     easy = Ethon::Easy.new(url: url)
@@ -20,14 +20,13 @@ module NewRelic::Security
                     @output = response
                     assert_equal :ok, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 1, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
-                    $event_list.clear()
                     url = "https://www.google.com"
                     args = [{:scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil}]
                     easy = Ethon::Easy.new(url: url)
@@ -35,14 +34,13 @@ module NewRelic::Security
                     @output = response
                     assert_equal :ok, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 1, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books"
                     args = [{:Method=>:post, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\" : \"New Book\", \"author\": \"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
                     # response = HTTPX.post(url, :json => {:name => "testuser", :salary => "123", :age => "23"})
@@ -52,14 +50,13 @@ module NewRelic::Security
                     response = easy.perform
                     assert_equal :ok, response
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 1, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>:put, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\": \"Update Book\", \"author\": \"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
                     # response = HTTPX.put(url, :json => {:name => "testuser", :salary => "123",:age => "23"})
@@ -69,14 +66,13 @@ module NewRelic::Security
                     response = easy.perform
                     assert_equal :ok, response
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 1, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>:delete, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>nil, :Headers=>{"User-Agent"=>"ethon"}}]
                     # response = HTTPX.delete(url)
@@ -86,24 +82,25 @@ module NewRelic::Security
                     response = easy.perform
                     assert_equal :ok, response
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 1, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def teardown
+                    $event_list.clear()
                     NewRelic::Security::Agent::Control::HTTPContext.reset_context
                 end
             end
 
             class TestEthonMulti < Minitest::Test
                 def setup
+                    $event_list.clear()
                     NewRelic::Security::Agent::Control::HTTPContext.set_context({})
                 end
 
                 def test_get
-                    $event_list.clear()
                     url = "http://www.google.com"
                     args = [{:Method=>:get, :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>nil}, {:Method=>:get, :scheme=>"https", :host=>"newrelic.com", :port=>443, :URI=>"https://newrelic.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"User-Agent"=>"ethon"}}]
 
@@ -121,13 +118,14 @@ module NewRelic::Security
                     response = multi.perform
                     assert_nil response
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 1, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
                 
                 def teardown
+                    $event_list.clear()
                     NewRelic::Security::Agent::Control::HTTPContext.reset_context
                 end
             end

--- a/test/newrelic_security/instrumentation-security/excon/excon_test.rb
+++ b/test/newrelic_security/instrumentation-security/excon/excon_test.rb
@@ -8,14 +8,15 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestExcon < Minitest::Test
-                def test_excon
+                def setup
                     $event_list.clear()
+                end
+
+                def test_excon
                     url = "https://www.google.com"
                     @output = Excon.get(url).body
-                    case_type = "HTTP_REQUEST"
                     args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"www.google.com", :path=>"", :query=>nil, :Body=>nil}]
-                    event_category = nil
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
@@ -23,9 +24,9 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
                     assert_equal expected_event.parameters[0][:path], $event_list[0].parameters[0][:path]
-                    assert_nil expected_event.parameters[0][:query], $event_list[0].parameters[0][:query]
-                    assert_nil expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].parameters[0][:query]
+                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_nil $event_list[0].eventCategory
                 end
                 
                 # def test_faraday_excon

--- a/test/newrelic_security/instrumentation-security/file/file_test.rb
+++ b/test/newrelic_security/instrumentation-security/file/file_test.rb
@@ -6,7 +6,7 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestFile < Minitest::Test
-                TEMP_DIR = $test_path + "/resources/temp"
+                TEMP_DIR = TEST_PATH + "/resources/temp"
                 TEMP_FILE = TEMP_DIR + "/abc.txt"
                 
                 def test_delete

--- a/test/newrelic_security/instrumentation-security/file/file_test.rb
+++ b/test/newrelic_security/instrumentation-security/file/file_test.rb
@@ -6,36 +6,33 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestFile < Minitest::Test
-                @@temp_dir = $test_path + "/resources/temp"
-                @@temp_file = @@temp_dir + "/abc.txt"
-                @@case_type = "FILE_INTEGRITY"
-                @@args = [@@temp_file]
-                @@event_category = nil
+                TEMP_DIR = $test_path + "/resources/temp"
+                TEMP_FILE = TEMP_DIR + "/abc.txt"
                 
                 def test_delete
-                    Dir.mkdir(@@temp_dir) unless Dir.exist?(@@temp_dir)
-                    File.new(@@temp_file, "w") unless File.exist?(@@temp_file)
+                    Dir.mkdir(TEMP_DIR) unless Dir.exist?(TEMP_DIR)
+                    File.new(TEMP_FILE, "w") unless File.exist?(TEMP_FILE)
                     $event_list.clear()
-                    out = File.delete(@@temp_file)
+                    out = File.delete(TEMP_FILE)
                     assert_equal 1, out
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_INTEGRITY, [TEMP_FILE], DELETE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_INTEGRITY)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_unlink
-                    Dir.mkdir(@@temp_dir) unless Dir.exist?(@@temp_dir)
-                    File.new(@@temp_file, "w") unless File.exist?(@@temp_file)
+                    Dir.mkdir(TEMP_DIR) unless Dir.exist?(TEMP_DIR)
+                    File.new(TEMP_FILE, "w") unless File.exist?(TEMP_FILE)
                     $event_list.clear()
-                    out = File.unlink(@@temp_file)
+                    out = File.unlink(TEMP_FILE)
                     assert_equal 1, out
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_INTEGRITY, [TEMP_FILE], DELETE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_INTEGRITY)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
             end
         end

--- a/test/newrelic_security/instrumentation-security/httpclient/httpclient_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpclient/httpclient_test.rb
@@ -1,76 +1,67 @@
 require 'httpclient'
 require_relative '../../../test_helper'
-require 'newrelic_security/instrumentation-security/net_http/instrumentation'
 require 'newrelic_security/instrumentation-security/httpclient/instrumentation'
-require 'newrelic_security/instrumentation-security/io/instrumentation'
 
 module NewRelic::Security
     module Test
         module Instrumentation
             class TestHTTPClient < Minitest::Test
-                @@url = "https://www.google.com"
-                @@case_type = "HTTP_REQUEST"
-                @@event_category = nil
+
+                def setup
+                    $event_list.clear()
+                end
                 
                 def test_get_content
-                    $event_list.clear()
                     url = "https://www.google.com"
                     client = HTTPClient.new
 	                @output = client.get_content(url)
                     #puts @output
                     args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_request
-                    $event_list.clear()
                     url = "https://www.google.com"
                     client = HTTPClient.new
                     method = 'GET'
-                    @output = client.request(method, url).code
-                    assert_equal 200, @output 
+                    assert_equal 200, client.request(method, url).code
                     args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get
-                    $event_list.clear()
                     url = "https://www.google.com"
                     client = HTTPClient.new
-	                @output = client.get(url, :follow_redirect => true).code 
-                    assert_equal 200, @output 
+                    assert_equal 200, client.get(url, :follow_redirect => true).code
                     args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_head
-                    $event_list.clear()
                     url = "https://www.google.com"
                     client = HTTPClient.new
-	                @output = client.head(url).code
-                    assert_equal 200, @output 
+                    assert_equal 200, client.head(url).code
                     args = [{:Method=>:head, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_async
-                    $event_list.clear()
                     url = "https://www.google.com"
                     client = HTTPClient.new
                     str = ""
@@ -82,30 +73,29 @@ module NewRelic::Security
                     #puts @output
                     #assert_equal 200, @output 
                     args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 # def test_uri_open
                 #     # URI.open test
-                #     $event_list.clear()
                 #     url = "https://www.google.com"
                 #     #client = HTTPClient.new
 	            #     @output = URI.open(url).read
                 #     # puts @output
                 #     case_type = "FILE_OPERATION"
                 #     args = ["www.google.com"]
-                #     expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, @@event_category)
-                #     assert_equal 3, $event_list.length
+                #     expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, nil)
+                #     assert_equal 3, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                 #     assert_equal expected_event.caseType, $event_list[0].caseType
                 #     assert_equal expected_event.parameters, $event_list[0].parameters
-                #     assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                #     assert_nil $event_list[0].eventCategory
 
                 #     args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :path=>"/", :query=>nil, :URI=>"https://www.google.com:443/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby"}}]
-                #     expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
+                #     expected_event2 = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                 #     assert_equal expected_event2.caseType, $event_list[1].caseType
                 #     assert_equal expected_event2.parameters, $event_list[1].parameters
                 #     assert_nil expected_event2.eventCategory, $event_list[1].eventCategory

--- a/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
+++ b/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
@@ -1,81 +1,74 @@
 require 'http'
 require_relative '../../../test_helper'
 require 'newrelic_security/instrumentation-security/httprb/instrumentation'
-# require 'newrelic_security/instrumentation-security/io/instrumentation'
 
 module NewRelic::Security
     module Test
         module Instrumentation
             class TestNetHTTP < Minitest::Test
 
-                def test_get
+                def setup
                     $event_list.clear()
+                end
+
+                def test_get
                     url = "http://www.google.com"
                     args = [{:Method=>:get, :scheme=>:http, :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com/?foo=bar", :path=>"/", :query=>"foo=bar", :Body=>"", :Headers=>{"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}}]
                     response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
-                    @output = response.code
-                    assert_equal 200, @output
+                    assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 2, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
-                    $event_list.clear()
                     url = "https://www.google.com"
                     args = [{:Method=>:get, :scheme=>:https, :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/?foo=bar", :path=>"/", :query=>"foo=bar", :Body=>"", :Headers=>{"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}}]
                     response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
-                    @output = response.code
-                    assert_equal 200, @output
+                    assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 2, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books"
                     args = [{:Method=>:post, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
                     response = HTTP.headers(args[0][:Headers]).post(url, :json => {:title => "New", :author => "New Author"} )
-                    @output = response.code
-                    assert_equal 201, @output
+                    assert_equal 201, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 2, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>:put, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
                     response = HTTP.headers(args[0][:Headers]).put(url, :json => {:title => "Update Book", :author => "Update Author"})
-                    @output = response.code
-                    assert_equal 200, @output
+                    assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 2, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>:delete, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
                     response = HTTP.delete(url)
-                    @output = response.code
-                    assert_equal 204, @output
+                    assert_equal 204, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
-                    assert_equal 2, $event_list.length
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
+++ b/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
@@ -5,7 +5,7 @@ require 'newrelic_security/instrumentation-security/httprb/instrumentation'
 module NewRelic::Security
     module Test
         module Instrumentation
-            class TestNetHTTP < Minitest::Test
+            class TestHTTP < Minitest::Test
 
                 def setup
                     $event_list.clear()

--- a/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
@@ -7,8 +7,11 @@ module NewRelic::Security
         module Instrumentation
             class TestHTTPX < Minitest::Test
 
-                def test_get
+                def setup
                     $event_list.clear()
+                end
+
+                def test_get
                     url = "http://www.google.com"
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>"", :Headers=>{}}]
                     response = HTTPX.get(url)
@@ -22,11 +25,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
-                    $event_list.clear()
                     url = "https://www.google.com"
                     args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>"", :Headers=>{}}]
                     response = HTTPX.get(url)
@@ -40,11 +42,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books"
                     args = [{:Method=>"POST", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{}}]
                     response = HTTPX.post(url, :json => {"title"=>"New","author"=>"New Author"})
@@ -58,11 +59,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>"PUT", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{}}]
                     response = HTTPX.put(url, :json => {"title"=>"Update Book","author"=>"Update Author"})
@@ -76,11 +76,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>"DELETE", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
                     response = HTTPX.delete(url)
@@ -94,7 +93,7 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/io/io_test.rb
+++ b/test/newrelic_security/instrumentation-security/io/io_test.rb
@@ -5,282 +5,263 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestIO < Minitest::Test
-                @@file_name = $test_path + "/resources/sample_file.txt"
-                @@file2_name = $test_path + "/resources/sample_file2.txt"
-                @@temp_file = $test_path + "/resources/tmp.txt"
-                @@case_type = "FILE_OPERATION"
-                @@args = [@@file_name]
-                @@event_category = nil
+                FILE_NAME = $test_path + "/resources/sample_file.txt"
+                FILE2_NAME = $test_path + "/resources/sample_file2.txt"
+                TEMP_FILE = $test_path + "/resources/tmp.txt"
+
+                def setup
+                    $event_list.clear()
+                end
 
                 def test_open
-                    $event_list.clear()
-                    file_fd = IO.sysopen(@@file_name,"r")
+                    file_fd = IO.sysopen(FILE_NAME,"r")
                     file = IO.open(file_fd, 'r')
                     file.close
                     
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     # puts $event_list[0].caseType, $event_list[0].eventCategory, $event_list[0].parameters
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory 
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters  
                 end
                 
                 def test_sysopen
-                    $event_list.clear()
-                    file_fd = IO.sysopen(@@file_name, "r")
+                    file_fd = IO.sysopen(FILE_NAME, "r")
                     file = IO.new(file_fd, "r")
                     output = file.read
                     assert_equal "This is a sample text file", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters  
                 end
 
                 def test_read
-                    $event_list.clear()
-                    output = IO.read(@@file_name)
+                    output = IO.read(FILE_NAME)
                     assert_equal "This is a sample text file", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters
                 end
 
                 def test_read_arg1
-                    $event_list.clear()
-                    output = IO.read(@@file_name, 21)
+                    output = IO.read(FILE_NAME, 21)
                     assert_equal "This is a sample text", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     #puts $event_list[0].caseType, $event_list[0].eventCategory, $event_list[0].parameters
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_read_arg2
-                    $event_list.clear()
-                    output = File.read(@@file_name, 11, 10)
+                    output = File.read(FILE_NAME, 11, 10)
                     assert_equal "sample text", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_read_mode
-                    $event_list.clear()
-                    output = File.read(@@file_name, mode: "r")
+                    output = File.read(FILE_NAME, mode: "r")
                     assert_equal "This is a sample text file", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_readlines
-                    $event_list.clear()
-                    output = IO.readlines(@@file_name)
+                    output = IO.readlines(FILE_NAME)
                     assert_equal "This is a sample text file", output[0]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_readlines_arg
-                    $event_list.clear()
-                    output = IO.readlines(@@file2_name, chomp: true)
-                    #output = IO.readlines(@@file2_name)
+                    output = IO.readlines(FILE2_NAME, chomp: true)
+                    #output = IO.readlines(FILE2_NAME)
                     assert_equal "First line", output[0]
-                    args = [@@file2_name]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args = [FILE2_NAME]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_binread
-                    $event_list.clear()
-                    output = IO.binread(@@file_name)
+                    output = IO.binread(FILE_NAME)
                     assert_equal "This is a sample text file", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_binread_arg1   
-                    $event_list.clear() 
-                    output = IO.binread(@@file_name, 21)
+                    output = IO.binread(FILE_NAME, 21)
                     assert_equal "This is a sample text", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_binread_arg2    
-                    $event_list.clear()
-                    output = File.binread(@@file_name, 11, 10)
+                    output = File.binread(FILE_NAME, 11, 10)
                     assert_equal "sample text", output          
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_new_read 
-                    $event_list.clear()
-                    file_fd = IO.sysopen(@@file_name,"r")
+                    file_fd = IO.sysopen(FILE_NAME,"r")
                     file = IO.new(file_fd,"r")
                     output = file.read
                     assert_equal "This is a sample text file", output
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters
                 end
 
                 def test_new_write 
-                    $event_list.clear()
-                    file_fd = IO.sysopen(@@temp_file, "w")
+                    file_fd = IO.sysopen(TEMP_FILE, "w")
                     file = IO.new(file_fd,"w")
                     file.puts "This is a temp text file"
                     file.close
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters
-                    output = IO.read(@@temp_file)
+                    output = IO.read(TEMP_FILE)
                     assert_equal "This is a temp text file\n", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_new_write_utf 
-                    $event_list.clear()
-                    file_fd = IO.sysopen(@@temp_file, "w")
+                    file_fd = IO.sysopen(TEMP_FILE, "w")
                     file = io = IO.new(file_fd, mode: 'w:UTF-16LE', cr_newline: true)
                     file.puts "Temp file"
                     file.close
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters
-                    # output = IO.read(@@temp_file)
+                    # output = IO.read(TEMP_FILE)
                     # assert_equal "This is a temp text file\n", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_new_write_external_encoding 
-                    $event_list.clear()
-                    file_fd = IO.sysopen(@@temp_file, "w")
+                    file_fd = IO.sysopen(TEMP_FILE, "w")
                     file = IO.new(file_fd, mode: 'w', cr_newline: true, external_encoding: Encoding::UTF_16LE)
                     file.puts "Temp file"
                     file.close
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                     # TODO: update parameter when have http_context 
                     # assert_equal expected_event.parameters, $event_list[0].parameters
-                    # output = IO.read(@@temp_file)
+                    # output = IO.read(TEMP_FILE)
                     # assert_equal "This is a temp text file\n", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_foreach 
-                    $event_list.clear()
-                    IO.foreach(@@file_name, "r") {|x| assert_equal x, "This is a sample text file"}
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    IO.foreach(FILE_NAME, "r") {|x| assert_equal x, "This is a sample text file"}
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, [FILE_NAME], READ)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
                 end
 
                 def test_write
-                    $event_list.clear()
-                    IO.write(@@temp_file, "Temp file")
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    IO.write(TEMP_FILE, "Temp file")
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
-                    output = IO.read(@@temp_file)
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
+                    output = IO.read(TEMP_FILE)
                     assert_equal "Temp file", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_write_arg
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                     $event_list.clear()
-                    IO.write(@@temp_file, "Temp file", 0)
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    IO.write(TEMP_FILE, "Temp file", 0)
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
-                    output = IO.read(@@temp_file)
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
+                    output = IO.read(TEMP_FILE)
                     assert_equal "Temp file", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_binwrite
-                    $event_list.clear()
-                    IO.binwrite(@@temp_file, "Temp file")
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    IO.binwrite(TEMP_FILE, "Temp file")
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
-                    output = IO.read(@@temp_file)
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
+                    output = IO.read(TEMP_FILE)
                     assert_equal "Temp file", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_binwrite_arg
-                    $event_list.clear()
-                    IO.binwrite(@@temp_file, "Temp file", 0)
-                    args = [@@temp_file]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    IO.binwrite(TEMP_FILE, "Temp file", 0)
+                    args = [TEMP_FILE]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(FILE_OPERATION, args, WRITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(FILE_OPERATION)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
-                    output = IO.read(@@temp_file)
+                    assert_equal expected_event.eventCategory, $event_list[0].eventCategory
+                    output = IO.read(TEMP_FILE)
                     assert_equal "Temp file", output
-                    File.delete(@@temp_file) if File.exist?(@@temp_file)
+                    File.delete(TEMP_FILE) if File.exist?(TEMP_FILE)
                 end
 
                 def test_popen
-                    $event_list.clear()
                     current_path = __dir__
                     cmd = "ls " + current_path
                     f = IO.popen(cmd)
@@ -288,13 +269,16 @@ module NewRelic::Security
                     #puts output
                     f.close
                     assert_equal "io_test.rb\n", output
-                    case_type = "SYSTEM_COMMAND"
                     args = [cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
+                end
+
+                def teardown
+                    $event_list.clear()
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/io/io_test.rb
+++ b/test/newrelic_security/instrumentation-security/io/io_test.rb
@@ -5,9 +5,9 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestIO < Minitest::Test
-                FILE_NAME = $test_path + "/resources/sample_file.txt"
-                FILE2_NAME = $test_path + "/resources/sample_file2.txt"
-                TEMP_FILE = $test_path + "/resources/tmp.txt"
+                FILE_NAME = TEST_PATH + "/resources/sample_file.txt"
+                FILE2_NAME = TEST_PATH + "/resources/sample_file2.txt"
+                TEMP_FILE = TEST_PATH + "/resources/tmp.txt"
 
                 def setup
                     $event_list.clear()

--- a/test/newrelic_security/instrumentation-security/kernel/kernel_test.rb
+++ b/test/newrelic_security/instrumentation-security/kernel/kernel_test.rb
@@ -5,7 +5,7 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestKernel < Minitest::Test
-                TEMP_FILE = $test_path + "/resources/tmp.txt"
+                TEMP_FILE = TEST_PATH + "/resources/tmp.txt"
                 # def test_require
                 #    #out = require 'temp_module'
                 # end

--- a/test/newrelic_security/instrumentation-security/kernel/kernel_test.rb
+++ b/test/newrelic_security/instrumentation-security/kernel/kernel_test.rb
@@ -5,125 +5,115 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestKernel < Minitest::Test
-                @@file_name = $test_path + "/resources/sample_file.txt"
-                @@temp_file = $test_path + "/resources/tmp.txt"
-                @@case_type = "SYSTEM_COMMAND"
-                @@args = [@@file_name]
-                @@event_category = nil
+                TEMP_FILE = $test_path + "/resources/tmp.txt"
                 # def test_require
                 #    #out = require 'temp_module'
                 # end
+
+                def setup
+                    $event_list.clear()
+                end
                 
                 def test_system
-                    $event_list.clear()
                     cmd = "pwd"
                     out = system(cmd)
                     assert_equal true, out
-                    args = [cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, [cmd], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
                 
                 def test_backtick
-                    $event_list.clear()
-                    cmd = "touch #{@@temp_file}"
+                    cmd = "touch #{TEMP_FILE}"
                     `#{cmd}` 
-                    args = [cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, [cmd], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
         
-                    is_file_created = File.exist?(@@temp_file)
+                    is_file_created = File.exist?(TEMP_FILE)
                     assert_equal true, is_file_created
-                    File.delete(@@temp_file) if is_file_created
+                    File.delete(TEMP_FILE) if is_file_created
                 end
 
                 def test_delimiter
-                    $event_list.clear()
-                    cmd = "touch #{@@temp_file}"
+                    cmd = "touch #{TEMP_FILE}"
                     @output = %x(#{cmd})
-                    args = [cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, [cmd], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
         
-                    is_file_created = File.exist?(@@temp_file)
+                    is_file_created = File.exist?(TEMP_FILE)
                     assert_equal true, is_file_created
-                    File.delete(@@temp_file) if is_file_created
+                    File.delete(TEMP_FILE) if is_file_created
                 end
 
                 def test_delimiter2
-                    $event_list.clear()
-                    cmd = "touch #{@@temp_file}"
+                    cmd = "touch #{TEMP_FILE}"
                     @output = %x`#{cmd}`
-                    args = [cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, [cmd], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
         
-                    is_file_created = File.exist?(@@temp_file)
+                    is_file_created = File.exist?(TEMP_FILE)
                     assert_equal true, is_file_created
-                    File.delete(@@temp_file) if is_file_created
+                    File.delete(TEMP_FILE) if is_file_created
                 end
 
                 def test_spawn
-                    $event_list.clear()
-                    cmd = "touch #{@@temp_file}" 
+                    cmd = "touch #{TEMP_FILE}"
                     spawn("#{cmd}")
                     sleep 0.01
-                    args = [cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, [cmd], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
         
-                    is_file_created = File.exist?(@@temp_file)
+                    is_file_created = File.exist?(TEMP_FILE)
                     assert_equal true, is_file_created
-                    File.delete(@@temp_file) if is_file_created
+                    File.delete(TEMP_FILE) if is_file_created
                 end
                 
                 # def test_fork_exec 
-                #     $event_list.clear()
                 #     #TODO Not hooked
-                #     cmd = "touch #{@@temp_file}"
+                #     cmd = "touch #{TEMP_FILE}"
                 #     fork{exec("#{cmd}")}
                 #     sleep 0.01
-                #     args = [cmd]
-                #     expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                #     assert_equal 1, $event_list.length
+                #     expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, [cmd], nil)
+                #     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                 #     assert_equal expected_event.caseType, $event_list[0].caseType
                 #     assert_equal expected_event.parameters, $event_list[0].parameters
-                #     assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                #     assert_nil $event_list[0].eventCategory
         
-                #     is_file_created = File.exist?(@@temp_file)
+                #     is_file_created = File.exist?(TEMP_FILE)
                 #     assert_equal true, is_file_created
-                #     File.delete(@@temp_file) if is_file_created
+                #     File.delete(TEMP_FILE) if is_file_created
                 # end
                 
                 def test_open
-                    $event_list.clear()
-                    cmd = "touch #{@@temp_file}"
+                    cmd = "touch #{TEMP_FILE}"
                     open("\|#{cmd}").read
-                    args = ['|' + cmd]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SYSTEM_COMMAND, ['|' + cmd], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SYSTEM_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
         
-                    is_file_created = File.exist?(@@temp_file)
+                    is_file_created = File.exist?(TEMP_FILE)
                     assert_equal true, is_file_created
-                    File.delete(@@temp_file) if is_file_created
+                    File.delete(TEMP_FILE) if is_file_created
+                end
+
+                def teardown
+                    $event_list.clear()
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/mongo/mongo_test.rb
+++ b/test/newrelic_security/instrumentation-security/mongo/mongo_test.rb
@@ -8,8 +8,6 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestMongo < Minitest::Test
-                @@case_type = "NOSQL_DB_COMMAND"
-                @@event_category = "MONGO"
                 @@before_all_flag = false
     
                 def setup
@@ -55,9 +53,9 @@ module NewRelic::Security
                     # insert count
                     assert_equal 1, @output.n         
                     args = [{:payload=>{:document=>{"name"=>"abc", "price"=>"5000"}, :opts=>{}}, :payloadType=>:insert}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
                     # event count and event data verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 1, mongo_events
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
@@ -74,11 +72,11 @@ module NewRelic::Security
                     args = [{:payload=>{:filter=>{"name"=>"abc"}, :update=>{"$set"=>{"name"=>"pqr"}}, :options=>{}}, :payloadType=>:update}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args3 = [{:payload=>{:filter=>{"name"=>"abc"}, :spec=>{"$set"=>{"name"=>"pqr"}}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args3, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 3, mongo_events
                     # update event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -101,9 +99,9 @@ module NewRelic::Security
                     assert_equal "pqr", @output["name"]
                     assert_equal "5000", @output["price"]
                     args = [{:payload=>{:filter=>{"name"=>"pqr"}, :options=>{}}, :payloadType=>:find}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 1, mongo_events
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
@@ -117,11 +115,11 @@ module NewRelic::Security
                     args = [{:payload=>{:filter=>{"name"=>"pqr"}, :options=>{}}, :payloadType=>:delete}]
                     args2 = [{:payload=>{:filter=>{"name"=>"pqr"}, :options=>{}}, :payloadType=>:find}]
                     args3 = [{:payload=>{:filter=>{"name"=>"pqr"}, :opts=>{}}, :payloadType=>:delete}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args3, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 3, mongo_events
                     # delete event
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -160,9 +158,9 @@ module NewRelic::Security
                     assert_equal 2, @output     
                     # event verify    
                     args = [{:payload=>{:documents=>[{:_id=>1, :name=>"abc", :price=>"5000"}, {:_id=>2, :name=>"pqr", :price=>"1000"}], :options=>{}}, :payloadType=>:insert}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 1, mongo_events
                     # event data verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -177,11 +175,11 @@ module NewRelic::Security
                     args = [{:payload=>{:filter=>{}, :update=>{"$set"=>{:price=>"2000"}}, :options=>{}}, :payloadType=>:update}]
                     args2 = [{:payload=>{:filter=>{}, :options=>{}}, :payloadType=>:find}]
                     args3 = [{:payload=>{:filter=>{}, :spec=>{"$set"=>{:price=>"2000"}}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args3, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 3, mongo_events
                     # update_many event verify
                     assert_equal expected_event1.caseType, $event_list[0].caseType
@@ -208,9 +206,9 @@ module NewRelic::Security
                     assert_equal [2, "pqr", "2000"], [@output[3], @output[4], @output[5]]
                     # event verify
                     args = [{:payload=>{:filter=>nil, :options=>{}}, :payloadType=>:find}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 1, mongo_events
                     # event data verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -224,11 +222,11 @@ module NewRelic::Security
                     args = [{:payload=>{:filter=>{:price=>"2000"}, :options=>{}}, :payloadType=>:delete}]
                     args2 = [{:payload=>{:filter=>{:price=>"2000"}, :options=>{}}, :payloadType=>:find}]
                     args3 = [{:payload=>{:filter=>{"price"=>"2000"}, :opts=>{}}, :payloadType=>:delete}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args3, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 3, mongo_events
                     # delete_many event verify
                     assert_equal expected_event1.caseType, $event_list[0].caseType
@@ -268,9 +266,9 @@ module NewRelic::Security
                     assert_equal 1, @output.n        
                     #event verify    
                     args = [{:payload=>{:document=>{"name"=>"abc", "price"=>"5000"}, :opts=>{}}, :payloadType=>:insert}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
                     # event count and output data verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 1, mongo_events
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
@@ -305,10 +303,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :spec=>{"$set"=>{"name"=>"pqr"}}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -344,10 +342,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :opts=>{}}, :payloadType=>:delete}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # delete event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -385,10 +383,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :opts=>{}}, :payloadType=>:delete}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # delete event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -420,10 +418,10 @@ module NewRelic::Security
                     assert_equal 2, @output.modified_count  
                     args = [{:payload=>{:filter=>{:price=>"1000"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"price"=>"1000"}, :spec=>{"$set"=>{:price=>"4000"}}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update_many event verify
                     assert_equal expected_event1.caseType, $event_list[0].caseType
@@ -456,10 +454,10 @@ module NewRelic::Security
                     # event verify
                     args = [{:payload=>{:filter=>{:price=>"1000"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"price"=>"1000"}, :opts=>{}}, :payloadType=>:delete}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update_many event verify
                     assert_equal expected_event1.caseType, $event_list[0].caseType
@@ -497,10 +495,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :replacement=>{:name=>"pqr"}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -535,10 +533,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :replacement=>{:name=>"pqr"}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -573,10 +571,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :document=>{:name=>"pqr"}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -611,10 +609,10 @@ module NewRelic::Security
                     # event verify     
                     args = [{:payload=>{:filter=>{:name=>"abc"}, :options=>{}}, :payloadType=>:find}]
                     args2 = [{:payload=>{:filter=>{"name"=>"abc"}, :document=>{"$set"=>{:name=>"pqr"}}, :opts=>{}}, :payloadType=>:update}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args, MONGO)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(NOSQL_DB_COMMAND, args2, MONGO)
                     # event count verify
-                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    mongo_events = NewRelic::Security::Agent::Control::Collector.get_event_count(NOSQL_DB_COMMAND)
                     assert_equal 2, mongo_events
                     # update event verify
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/mysql2/mysql2_test.rb
+++ b/test/newrelic_security/instrumentation-security/mysql2/mysql2_test.rb
@@ -171,7 +171,7 @@ module NewRelic::Security
                     expected_result = {"name"=>"john", "email"=>"me@john.com", "grade"=>"A", "blog"=>"http://blog.abc.com"}
                     assert_equal expected_result, @output
                     # event verification
-                    args = [{:parameters=>["john"]}]
+                    args = [{:sql=>"SELECT * FROM fake_users WHERE name = ?", :parameters=>["john"]}]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -182,7 +182,7 @@ module NewRelic::Security
                     # DELETE event test 
                     statement = client.prepare("DELETE FROM fake_users WHERE name= ?") 
                     statement.execute("john")
-                    args = [{:parameters=>["john"]}]
+                    args = [{:sql=>"DELETE FROM fake_users WHERE name= ?", :parameters=>["john"]}]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/mysql2/mysql2_test.rb
+++ b/test/newrelic_security/instrumentation-security/mysql2/mysql2_test.rb
@@ -7,8 +7,6 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestMysql2 < Minitest::Test
-                @@case_type = "SQL_DB_COMMAND"
-                @@event_category = "MYSQL"
                 @@before_all_flag = false
     
                 def setup
@@ -51,8 +49,8 @@ module NewRelic::Security
                     # CREATE event test 
                     client.query("create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))")
                     args = [{:sql=>"create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -61,8 +59,8 @@ module NewRelic::Security
                     # INSERT event test 
                     client.query("INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com')")
                     args = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com')", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -71,8 +69,8 @@ module NewRelic::Security
                     # UPDATE event test 
                     client.query("UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'")
                     args = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -88,8 +86,8 @@ module NewRelic::Security
                     assert_equal expected_result, @output
                     # event verification
                     args = [{:sql=>"SELECT * FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -98,8 +96,8 @@ module NewRelic::Security
                     # DELETE event test 
                     client.query("DELETE FROM fake_users WHERE name= 'john'") 
                     args = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -115,8 +113,8 @@ module NewRelic::Security
                     # DROP event test 
                     client.query("DROP TABLE fake_users") 
                     args = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -132,8 +130,8 @@ module NewRelic::Security
                     # CREATE event test 
                     client.query("create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))")
                     args = [{:sql=>"create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -143,8 +141,8 @@ module NewRelic::Security
                     statement = client.prepare("INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)")
                     statement.execute("abc", "me@abc.com", "A", "http://blog.abc.com")
                     args = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", :parameters=>["abc", "me@abc.com", "A", "http://blog.abc.com"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -154,8 +152,8 @@ module NewRelic::Security
                     statement = client.prepare("UPDATE fake_users SET name = ?, email= ? WHERE name = ?")
                     statement.execute("john", "me@john.com", "abc")
                     args = [{:sql=>"UPDATE fake_users SET name = ?, email= ? WHERE name = ?", :parameters=>["john", "me@john.com", "abc"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -172,8 +170,8 @@ module NewRelic::Security
                     assert_equal expected_result, @output
                     # event verification
                     args = [{:sql=>"SELECT * FROM fake_users WHERE name = ?", :parameters=>["john"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -183,8 +181,8 @@ module NewRelic::Security
                     statement = client.prepare("DELETE FROM fake_users WHERE name= ?") 
                     statement.execute("john")
                     args = [{:sql=>"DELETE FROM fake_users WHERE name= ?", :parameters=>["john"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -200,8 +198,8 @@ module NewRelic::Security
                     # DROP event test 
                     client.query("DROP TABLE fake_users") 
                     args = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, MYSQL)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory

--- a/test/newrelic_security/instrumentation-security/net_http/net_http_test.rb
+++ b/test/newrelic_security/instrumentation-security/net_http/net_http_test.rb
@@ -7,9 +7,6 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestNetHTTP < Minitest::Test
-                @@case_type = "HTTP_REQUEST"
-                @@args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"close"}}]
-                @@event_category = nil
 
                 # def test_get
                 #     url = "http://www.google.com"
@@ -17,39 +14,39 @@ module NewRelic::Security
                 #     puts @output
                 # end
 
-                def test_get_request
+                def setup
                     $event_list.clear()
+                end
+
+                def test_get_request
                     url = "http://www.google.com"
                     uri = URI.parse("#{url}")
                     http = Net::HTTP.new(uri.host, uri.port)
                     request = Net::HTTP::Get.new(uri.request_uri)
                     response = http.request(request)
-                    @output = response.code
-                    assert_equal "200", @output
-
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, @@args, @@event_category)
-                    assert_equal 2, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[1].caseType
-                    assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    assert_equal "200", response.code
+                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"close"}}]
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_uri
-                    $event_list.clear()
                     url = "http://www.google.com"
                     uri = URI(url)
                     @output = Net::HTTP.get(uri)
                     #puts @output
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[1].caseType
-                    assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_response_dynamic
-                    $event_list.clear()
                     url = "http://www.google.com"
                     uri = URI(url)
                     uri_params = { :limit => 10, :page => 3 }
@@ -57,15 +54,14 @@ module NewRelic::Security
                     @output = Net::HTTP.get_response(uri)
                     assert_equal "200", @output.code
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com?limit=10&page=3", :path=>"", :query=>"limit=10&page=3", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[1].caseType
-                    assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
                 
                 def test_get_start
-                    $event_list.clear()
                     url = "http://www.google.com"
                     uri = URI(url)
                     Net::HTTP.start(uri.host, uri.port) do |http|
@@ -75,15 +71,14 @@ module NewRelic::Security
                     end
                     assert_equal "200", @output.code
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[1].caseType
-                    assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_start_ssl
-                    $event_list.clear()
                     url = "http://www.google.com"
                     uri = URI(url)
                     Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
@@ -92,15 +87,14 @@ module NewRelic::Security
                     end
                     assert_equal "200", @output.code
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[1].caseType
-                    assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_persistent_request
-                    $event_list.clear()
                     url = "http://www.google.com"
                     http = Net::HTTP::Persistent.new name: 'my_app_name'
                     uri = URI(url)
@@ -108,11 +102,11 @@ module NewRelic::Security
                     @output = response.code
                     assert_equal "200", @output
                     args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"keep-alive", "keep-alive"=>"30"}}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 2, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[1].caseType
-                    assert_equal expected_event.parameters, $event_list[1].parameters
-                    assert_nil expected_event.eventCategory, $event_list[1].eventCategory
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 # def test_open

--- a/test/newrelic_security/instrumentation-security/net_ldap/net_ldap_test.rb
+++ b/test/newrelic_security/instrumentation-security/net_ldap/net_ldap_test.rb
@@ -1,15 +1,17 @@
 require 'net/ldap'
 require_relative '../../../test_helper'
 require 'newrelic_security/instrumentation-security/net_ldap/instrumentation'
-require 'newrelic_security/instrumentation-security/io/instrumentation'
 
 module NewRelic::Security
     module Test
         module Instrumentation
             class TestNetLDAP < Minitest::Test
+                
+                def setup
+                    $event_list.clear()
+                end
 
                 def test_search 
-                    $event_list.clear()
                     ldap = Net::LDAP.new(
                         host: 'ldap.forumsys.com',
                         port: 389,
@@ -39,14 +41,11 @@ module NewRelic::Security
                     end
                     assert_equal "uid=gauss,dc=example,dc=com", output
                     # event verify
-                    case_type = "LDAP"
-                    args = [{:name=> base, :filter=> filter}]
-                    event_category = nil
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
-                    assert_equal 5, $event_list.length
-                    assert_equal expected_event.caseType, $event_list[2].caseType
-                    assert_equal expected_event.parameters, $event_list[2].parameters
-                    assert_nil expected_event.eventCategory, $event_list[2].eventCategory
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(LDAP, [{:name=> base, :filter=> filter}], nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(LDAP)
+                    assert_equal expected_event.caseType, $event_list[0].caseType
+                    assert_equal expected_event.parameters, $event_list[0].parameters
+                    assert_nil $event_list[0].eventCategory
                 end
                 
             end

--- a/test/newrelic_security/instrumentation-security/nokogiri/nokogiri_test.rb
+++ b/test/newrelic_security/instrumentation-security/nokogiri/nokogiri_test.rb
@@ -13,18 +13,17 @@ module NewRelic::Security
                     $event_list.clear()
                     doc = Nokogiri::XML(f)
                     output = doc.xpath(".//employee[firstName[text()=#{input.to_s}]")
+                    f.close
                     # data verify 
                     assert_equal "1", output[0].attr('id')
                     assert_equal "2", output[1].attr('id')
                     # event verify
-                    case_type = "XPATH"
                     args = [{:paths=>[".//employee[firstName[text()='xyx'] or 1]"], :variables=>nil}]
-                    event_category = nil
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(XPATH, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(XPATH)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
                 
             end

--- a/test/newrelic_security/instrumentation-security/patron/patron_test.rb
+++ b/test/newrelic_security/instrumentation-security/patron/patron_test.rb
@@ -6,22 +6,24 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestPatron < Minitest::Test
-                def test_patron_session_get
+
+                def setup
                     $event_list.clear()
+                end
+
+                def test_patron_session_get
                     url = "https://www.google.com"
                     sess = Patron::Session.new({ :timeout => 10,
                                             :base_url => url,
                                             :headers => {'User-Agent' => 'myapp/1.0'} } )
                     @output = sess.get("/").body
                     #puts @output
-                    case_type = "HTTP_REQUEST"
                     args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/", :path=>"/", :query=>nil, :Body=>nil, :Headers=>{"Expect"=>""}}]
-                    event_category = nil
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
             end
         end

--- a/test/newrelic_security/instrumentation-security/pg/pg_test.rb
+++ b/test/newrelic_security/instrumentation-security/pg/pg_test.rb
@@ -141,7 +141,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
                     expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, POSTGRES)
                     puts "$event_list : #{$event_list.inspect}"
-                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory

--- a/test/newrelic_security/instrumentation-security/pg/pg_test.rb
+++ b/test/newrelic_security/instrumentation-security/pg/pg_test.rb
@@ -7,8 +7,6 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestPG < Minitest::Test
-                @@case_type = "SQL_DB_COMMAND"
-                @@event_category = "POSTGRES"
                 @@before_all_flag = false
     
                 def setup
@@ -50,8 +48,8 @@ module NewRelic::Security
                     # CREATE event test 
                     client.exec("create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))")
                     args = [{:sql=>"create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -60,8 +58,8 @@ module NewRelic::Security
                     # INSERT event test 
                     client.exec("INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com')")
                     args = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com')", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -70,8 +68,8 @@ module NewRelic::Security
                     # UPDATE event test 
                     client.exec("UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'")
                     args = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -87,8 +85,8 @@ module NewRelic::Security
                     assert_equal expected_result, @output
                     # event verification
                     args = [{:sql=>"SELECT * FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -97,8 +95,8 @@ module NewRelic::Security
                     # DELETE event test 
                     client.exec("DELETE FROM fake_users WHERE name= 'john'") 
                     args = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -114,8 +112,8 @@ module NewRelic::Security
                     # DROP event test 
                     client.exec("DROP TABLE fake_users") 
                     args = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -140,10 +138,10 @@ module NewRelic::Security
                     # event verify
                     args = [{:sql=>"select statement from pg_prepared_statements where name = 'insert_statement'", :parameters=>[]}]
                     args2 = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES ($1, $2, $3, $4)", :parameters=>["abc", "me@abc.com", "A", "http://blog.abc.com"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, POSTGRES)
                     puts "$event_list : #{$event_list.inspect}"
-                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -163,9 +161,9 @@ module NewRelic::Security
                     # event verify
                     args = [{:sql=>"select statement from pg_prepared_statements where name = 'update_statement'", :parameters=>[]}]
                     args2 = [{:sql=>"UPDATE fake_users SET name = $1, email= $2 WHERE name = $3", :parameters=>["john", "me@john.com", "abc"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, POSTGRES)
+                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -186,9 +184,9 @@ module NewRelic::Security
                     # event verification
                     args = [{:sql=>"select statement from pg_prepared_statements where name = 'select_statement'", :parameters=>[]}]
                     args2 = [{:sql=>"SELECT * FROM fake_users WHERE name = $1", :parameters=>["john"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, POSTGRES)
+                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory
@@ -208,9 +206,9 @@ module NewRelic::Security
                     # event verify
                     args = [{:sql=>"select statement from pg_prepared_statements where name = 'delete_statement'", :parameters=>[]}]
                     args2 = [{:sql=>"DELETE FROM fake_users WHERE name= $1", :parameters=>["john"]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, POSTGRES)
+                    assert_equal 2, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory        
@@ -229,8 +227,8 @@ module NewRelic::Security
                     # DROP event test 
                     client.exec("DROP TABLE fake_users") 
                     args = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event = NewRelic::Security::Agent::Control::Event.new(@@case_type, args, @@event_category)
-                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(@@case_type)
+                    expected_event = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args, POSTGRES)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event.caseType, $event_list[0].caseType
                     assert_equal expected_event.parameters, $event_list[0].parameters
                     assert_equal expected_event.eventCategory, $event_list[0].eventCategory

--- a/test/newrelic_security/instrumentation-security/pty/pty_test.rb
+++ b/test/newrelic_security/instrumentation-security/pty/pty_test.rb
@@ -6,7 +6,7 @@ module NewRelic::Security
   module Test
     module Instrumentation
       class TestPTY < Minitest::Test
-        TEMP_FILE = $test_path + "/resources/tmp.txt"
+        TEMP_FILE = TEST_PATH + "/resources/tmp.txt"
 
         def setup
           $event_list.clear()
@@ -28,7 +28,7 @@ module NewRelic::Security
           PTY::getpty("#{cmd}") do |reader, writer, pid|
             while true
               begin
-                puts reader.readline
+                reader.readline
               rescue
                 break
               end

--- a/test/newrelic_security/instrumentation-security/rails/rails_test.rb
+++ b/test/newrelic_security/instrumentation-security/rails/rails_test.rb
@@ -111,7 +111,7 @@ module NewRelic::Security
           assert_equal "GET", method
           assert_equal "/myapi", url
           assert_equal "", query_string
-          assert_equal nil, body
+          assert_nil body
           assert_equal "127.0.0.1", clientIP
           assert_equal "80", server_port
           assert_equal "www.example.com", server_name

--- a/test/newrelic_security/instrumentation-security/sinatra/sinatra_test.rb
+++ b/test/newrelic_security/instrumentation-security/sinatra/sinatra_test.rb
@@ -72,7 +72,7 @@ module NewRelic::Security
           assert_equal "GET", method
           assert_equal "/user/login", url
           assert_equal "John", query_string
-          assert_equal nil, body
+          assert_nil body
           assert_equal "127.0.0.1", clientIP
           assert_equal "80", server_port
           assert_equal "example.org", server_name

--- a/test/newrelic_security/instrumentation-security/sqlite3/sqlite3_test.rb
+++ b/test/newrelic_security/instrumentation-security/sqlite3/sqlite3_test.rb
@@ -6,8 +6,6 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestSqlite3 < Minitest::Test
-                @@case_type = "SQL_DB_COMMAND"
-                @@event_category = "SQLITE"
                 @@database_name = __dir__ + "/test.db"
 
                 def setup
@@ -23,8 +21,8 @@ module NewRelic::Security
                     create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); 
                     SQL
                     args1 = [{:sql=>"                    create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); \n", :parameters=>[]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event1.caseType, $event_list[0].caseType
                     assert_equal expected_event1.parameters, $event_list[0].parameters
                     assert_equal expected_event1.eventCategory, $event_list[0].eventCategory
@@ -34,8 +32,8 @@ module NewRelic::Security
                     db.execute("INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", ["abc", "me@abc.com", "A", "http://blog.abc.com"])
                     # puts @output.inspect
                     args2 = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", :parameters=>["abc", "me@abc.com", "A", "http://blog.abc.com"]}]
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event2.caseType, $event_list[0].caseType
                     assert_equal expected_event2.parameters, $event_list[0].parameters
                     assert_equal expected_event2.eventCategory, $event_list[0].eventCategory
@@ -44,8 +42,8 @@ module NewRelic::Security
                     # UPDATE event test
                     db.execute("UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'")
                     args3 = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'", :parameters=>[]}]
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args3, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event3.caseType, $event_list[0].caseType
                     assert_equal expected_event3.parameters, $event_list[0].parameters
                     assert_equal expected_event3.eventCategory, $event_list[0].eventCategory
@@ -56,8 +54,8 @@ module NewRelic::Security
                     expected_result = [["john", "me@john.com", "A", "http://blog.abc.com"]]
                     assert_equal expected_result, @output 
                     args4 = [{:sql=>"SELECT * FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args4, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args4, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event4.caseType, $event_list[0].caseType
                     assert_equal expected_event4.parameters, $event_list[0].parameters
                     assert_equal expected_event4.eventCategory, $event_list[0].eventCategory
@@ -66,8 +64,8 @@ module NewRelic::Security
                     # DELETE event test
                     db.execute("DELETE FROM fake_users WHERE name= 'john'")
                     args5 = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args5, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args5, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event5.caseType, $event_list[0].caseType
                     assert_equal expected_event5.parameters, $event_list[0].parameters
                     assert_equal expected_event5.eventCategory, $event_list[0].eventCategory
@@ -87,8 +85,8 @@ module NewRelic::Security
                     # DROP table test
                     db.execute("DROP TABLE fake_users")
                     args6 = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args6, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args6, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event6.caseType, $event_list[0].caseType
                     assert_equal expected_event6.parameters, $event_list[0].parameters
                     assert_equal expected_event6.eventCategory, $event_list[0].eventCategory
@@ -100,12 +98,10 @@ module NewRelic::Security
                     db.execute2("DROP TABLE IF EXISTS fake_users")
                     $event_list.clear()
                     # Create a table test
-                    db.execute2 <<-SQL
-                    create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); 
-                    SQL
-                    args1 = [{:sql=>"                    create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); \n", :parameters=>[]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    assert_equal 1, $event_list.length
+                    db.execute2("create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))")
+                    args1 = [{:sql=>"create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50))"}]
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event1.caseType, $event_list[0].caseType
                     assert_equal expected_event1.parameters, $event_list[0].parameters
                     assert_equal expected_event1.eventCategory, $event_list[0].eventCategory
@@ -114,8 +110,8 @@ module NewRelic::Security
                     # INSERT event test
                     db.execute2("INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", ["abc", "me@abc.com", "A", "http://blog.abc.com"])
                     args2 = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", :parameters=>["[\"abc\", \"me@abc.com\", \"A\", \"http://blog.abc.com\"]"]}]
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event2.caseType, $event_list[0].caseType
                     assert_equal expected_event2.parameters, $event_list[0].parameters
                     assert_equal expected_event2.eventCategory, $event_list[0].eventCategory
@@ -123,9 +119,9 @@ module NewRelic::Security
 
                     # UPDATE event test
                     db.execute2("UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'")
-                    args4 = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'", :parameters=>[]}]
-                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args4, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args4 = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'"}]
+                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args4, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event4.caseType, $event_list[0].caseType
                     assert_equal expected_event4.parameters, $event_list[0].parameters
                     assert_equal expected_event4.eventCategory, $event_list[0].eventCategory
@@ -135,9 +131,9 @@ module NewRelic::Security
                     @output = db.execute2("SELECT * FROM fake_users WHERE name= 'john'")
                     expected_result = [["name", "email", "grade", "blog"], ["john", "me@john.com", "A", "http://blog.abc.com"]]
                     assert_equal expected_result, @output 
-                    args3 = [{:sql=>"SELECT * FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args3 = [{:sql=>"SELECT * FROM fake_users WHERE name= 'john'"}]
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args3, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event3.caseType, $event_list[0].caseType
                     assert_equal expected_event3.parameters, $event_list[0].parameters
                     assert_equal expected_event3.eventCategory, $event_list[0].eventCategory
@@ -145,9 +141,9 @@ module NewRelic::Security
 
                     # DELETE event test
                     db.execute2("DELETE FROM fake_users WHERE name= 'john'")
-                    args5 = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'", :parameters=>[]}]
-                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args5, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args5 = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'"}]
+                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args5, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event5.caseType, $event_list[0].caseType
                     assert_equal expected_event5.parameters, $event_list[0].parameters
                     assert_equal expected_event5.eventCategory, $event_list[0].eventCategory
@@ -159,9 +155,9 @@ module NewRelic::Security
 
                     # DROP table test
                     db.execute2("DROP TABLE fake_users")
-                    args6 = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args6, @@event_category)
-                    assert_equal 1, $event_list.length
+                    args6 = [{:sql=>"DROP TABLE fake_users"}]
+                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args6, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event6.caseType, $event_list[0].caseType
                     assert_equal expected_event6.parameters, $event_list[0].parameters
                     assert_equal expected_event6.eventCategory, $event_list[0].eventCategory
@@ -178,8 +174,8 @@ module NewRelic::Security
                     create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); 
                     SQL
                     args1 = [{:sql=>"                    create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); \n", :parameters=>[]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event1.caseType, $event_list[0].caseType
                     assert_equal expected_event1.parameters, $event_list[0].parameters
                     assert_equal expected_event1.eventCategory, $event_list[0].eventCategory
@@ -188,8 +184,8 @@ module NewRelic::Security
                     # INSERT event test : 2 users entry 
                     db.execute_batch("INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com'); INSERT INTO fake_users (name, email, grade, blog) VALUES ('pqr', 'me@pqr.com', 'B', 'http://blog.pqr.com')")
                     args2 = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com'); INSERT INTO fake_users (name, email, grade, blog) VALUES ('pqr', 'me@pqr.com', 'B', 'http://blog.pqr.com')", :parameters=>[]}]
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event2.caseType, $event_list[0].caseType
                     assert_equal expected_event2.parameters, $event_list[0].parameters
                     assert_equal expected_event2.eventCategory, $event_list[0].eventCategory
@@ -205,8 +201,8 @@ module NewRelic::Security
                     # INSERT event test: using bind parameters
                     db.execute_batch("INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?); INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", ["xyz", "me@xyz.com", "C", "http://blog.xyz.com"])
                     args3 = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?); INSERT INTO fake_users (name, email, grade, blog) VALUES (?, ?, ?, ?)", :parameters=>["xyz", "me@xyz.com", "C", "http://blog.xyz.com"]}]
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args3, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event3.caseType, $event_list[0].caseType
                     assert_equal expected_event3.parameters, $event_list[0].parameters
                     assert_equal expected_event3.eventCategory, $event_list[0].eventCategory
@@ -219,8 +215,8 @@ module NewRelic::Security
                     # UPDATE event test
                     db.execute_batch("UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'; UPDATE fake_users SET name = 'jack', email= 'me@jack.com' WHERE name = 'pqr'")
                     args4 = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'; UPDATE fake_users SET name = 'jack', email= 'me@jack.com' WHERE name = 'pqr'", :parameters=>[]}]
-                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args4, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args4, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event4.caseType, $event_list[0].caseType
                     assert_equal expected_event4.parameters, $event_list[0].parameters
                     assert_equal expected_event4.eventCategory, $event_list[0].eventCategory
@@ -236,8 +232,8 @@ module NewRelic::Security
                     # DELETE event test
                     db.execute_batch("DELETE FROM fake_users WHERE name= 'john'; DELETE FROM fake_users WHERE name= 'jack'")
                     args5 = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'; DELETE FROM fake_users WHERE name= 'jack'", :parameters=>[]}]
-                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args5, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args5, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event5.caseType, $event_list[0].caseType
                     assert_equal expected_event5.parameters, $event_list[0].parameters
                     assert_equal expected_event5.eventCategory, $event_list[0].eventCategory
@@ -253,8 +249,8 @@ module NewRelic::Security
                     # DROP table test
                     db.execute_batch("DROP TABLE fake_users")
                     args6 = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args6, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args6, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event6.caseType, $event_list[0].caseType
                     assert_equal expected_event6.parameters, $event_list[0].parameters
                     assert_equal expected_event6.eventCategory, $event_list[0].eventCategory
@@ -271,8 +267,8 @@ module NewRelic::Security
                     create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); 
                     SQL
                     args1 = [{:sql=>"                    create table fake_users ( name varchar(50), email varchar(50), grade varchar(5), blog varchar(50)); \n", :parameters=>[]}]
-                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args1, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event1.caseType, $event_list[0].caseType
                     assert_equal expected_event1.parameters, $event_list[0].parameters
                     assert_equal expected_event1.eventCategory, $event_list[0].eventCategory
@@ -281,8 +277,8 @@ module NewRelic::Security
                     # INSERT event test : 2 users entry 
                     db.execute_batch2("INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com'); INSERT INTO fake_users (name, email, grade, blog) VALUES ('pqr', 'me@pqr.com', 'B', 'http://blog.pqr.com')")
                     args2 = [{:sql=>"INSERT INTO fake_users (name, email, grade, blog) VALUES ('abc', 'me@abc.com', 'A', 'http://blog.abc.com'); INSERT INTO fake_users (name, email, grade, blog) VALUES ('pqr', 'me@pqr.com', 'B', 'http://blog.pqr.com')", :parameters=>[]}]
-                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args2, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event2 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args2, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event2.caseType, $event_list[0].caseType
                     assert_equal expected_event2.parameters, $event_list[0].parameters
                     assert_equal expected_event2.eventCategory, $event_list[0].eventCategory
@@ -291,8 +287,8 @@ module NewRelic::Security
                     # UPDATE event test
                     db.execute_batch2("UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'; UPDATE fake_users SET name = 'jack', email= 'me@jack.com' WHERE name = 'pqr'")
                     args3 = [{:sql=>"UPDATE fake_users SET name = 'john', email= 'me@john.com' WHERE name = 'abc'; UPDATE fake_users SET name = 'jack', email= 'me@jack.com' WHERE name = 'pqr'", :parameters=>[]}]
-                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args3, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event3 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args3, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event3.caseType, $event_list[0].caseType
                     assert_equal expected_event3.parameters, $event_list[0].parameters
                     assert_equal expected_event3.eventCategory, $event_list[0].eventCategory
@@ -305,8 +301,8 @@ module NewRelic::Security
                     assert_equal expected_result, @output
                     # event verification
                     args4 = [{:sql=>"SELECT * FROM fake_users WHERE name= 'john'; SELECT * FROM fake_users WHERE name= 'jack'", :parameters=>[]}]
-                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args4, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event4 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args4, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event4.caseType, $event_list[0].caseType
                     assert_equal expected_event4.parameters, $event_list[0].parameters
                     assert_equal expected_event4.eventCategory, $event_list[0].eventCategory
@@ -315,8 +311,8 @@ module NewRelic::Security
                     # DELETE event test
                     db.execute_batch2("DELETE FROM fake_users WHERE name= 'john'; DELETE FROM fake_users WHERE name= 'jack'")
                     args5 = [{:sql=>"DELETE FROM fake_users WHERE name= 'john'; DELETE FROM fake_users WHERE name= 'jack'", :parameters=>[]}]
-                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args5, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event5 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args5, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event5.caseType, $event_list[0].caseType
                     assert_equal expected_event5.parameters, $event_list[0].parameters
                     assert_equal expected_event5.eventCategory, $event_list[0].eventCategory
@@ -332,8 +328,8 @@ module NewRelic::Security
                     # DROP table test
                     db.execute_batch2("DROP TABLE fake_users")
                     args6 = [{:sql=>"DROP TABLE fake_users", :parameters=>[]}]
-                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(@@case_type, args6, @@event_category)
-                    assert_equal 1, $event_list.length
+                    expected_event6 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args6, SQLITE)
+                    assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)
                     assert_equal expected_event6.caseType, $event_list[0].caseType
                     assert_equal expected_event6.parameters, $event_list[0].parameters
                     assert_equal expected_event6.eventCategory, $event_list[0].eventCategory

--- a/test/newrelic_security/instrumentation-security/sqlite3/sqlite3_test.rb
+++ b/test/newrelic_security/instrumentation-security/sqlite3/sqlite3_test.rb
@@ -10,6 +10,10 @@ module NewRelic::Security
                 @@event_category = "SQLITE"
                 @@database_name = __dir__ + "/test.db"
 
+                def setup
+                    NewRelic::Security::Agent::Control::HTTPContext.set_context({})
+                end
+
                 def test_execute
                     db = SQLite3::Database.new @@database_name
                     db.execute("DROP TABLE IF EXISTS fake_users")
@@ -334,6 +338,10 @@ module NewRelic::Security
                     assert_equal expected_event6.parameters, $event_list[0].parameters
                     assert_equal expected_event6.eventCategory, $event_list[0].eventCategory
                     $event_list.clear()
+                end
+
+                def teardown
+                    NewRelic::Security::Agent::Control::HTTPContext.reset_context
                 end
 
             end

--- a/test/newrelic_security/instrumentation-security/sqlite3/sqlite3_test.rb
+++ b/test/newrelic_security/instrumentation-security/sqlite3/sqlite3_test.rb
@@ -6,14 +6,14 @@ module NewRelic::Security
     module Test
         module Instrumentation
             class TestSqlite3 < Minitest::Test
-                @@database_name = __dir__ + "/test.db"
+                DATABASE_NAME = __dir__ + "/test.db"
 
                 def setup
                     NewRelic::Security::Agent::Control::HTTPContext.set_context({})
                 end
 
                 def test_execute
-                    db = SQLite3::Database.new @@database_name
+                    db = SQLite3::Database.new DATABASE_NAME
                     db.execute("DROP TABLE IF EXISTS fake_users")
                     $event_list.clear()
                     # Create a table test
@@ -94,7 +94,7 @@ module NewRelic::Security
                 end
 
                 def test_execute2
-                    db = SQLite3::Database.new @@database_name
+                    db = SQLite3::Database.new DATABASE_NAME
                     db.execute2("DROP TABLE IF EXISTS fake_users")
                     $event_list.clear()
                     # Create a table test
@@ -165,7 +165,7 @@ module NewRelic::Security
                 end
 
                 def test_execute_batch
-                    db = SQLite3::Database.new @@database_name
+                    db = SQLite3::Database.new DATABASE_NAME
                     db.execute_batch("DROP TABLE IF EXISTS fake_users")
                     $event_list.clear()
                     
@@ -258,7 +258,7 @@ module NewRelic::Security
                 end
 
                 def test_execute_batch2
-                    db = SQLite3::Database.new @@database_name
+                    db = SQLite3::Database.new DATABASE_NAME
                     db.execute_batch2("DROP TABLE IF EXISTS fake_users")
                     $event_list.clear()
                     

--- a/test/newrelic_security/instrumentation-security/typhoeus/typhoeus_test.rb
+++ b/test/newrelic_security/instrumentation-security/typhoeus/typhoeus_test.rb
@@ -8,11 +8,11 @@ module NewRelic::Security
             class TestTyphoeus < Minitest::Test
 
                 def setup
+                    $event_list.clear()
                     NewRelic::Security::Agent::Control::HTTPContext.set_context({})
                 end
 
                 def test_get
-                    $event_list.clear()
                     url = "http://www.google.com?q=test"
                     args = [{:Method=>:get, :URI=>"http://www.google.com?q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}, :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"", :query=>"q=test"}]
                     response = Typhoeus.get(url) # input=https://www.google.com
@@ -25,11 +25,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_nil $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
-                    $event_list.clear()
                     url = "https://www.google.com?q=test"
                     args = [{:Method=>:get, :URI=>"https://www.google.com?q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}, :scheme=>"https", :host=>"www.google.com", :port=>443, :path=>"", :query=>"q=test"}]
                     response = Typhoeus.get(url) # input=https://www.google.com
@@ -42,11 +41,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_nil $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books"
                     args = [{:Method=>:post, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books?field1=a%20field", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{:"Content-Type"=>"application/json"}}]
                     data = {"title"=>"New","author"=>"New Author"}
@@ -67,11 +65,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>:put, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1?field1=a%20field", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{:"Content-Type"=>"application/json"}}]
                     data = {"title"=>"Update Book","author"=>"Update Author"}
@@ -92,11 +89,10 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
-                    $event_list.clear()
                     url = "http://localhost:9291/books/1"
                     args = [{:Method=>:delete, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/api/v1/delete/1", :query=>nil, :Body=>nil, :Headers=>{}}]
                     request = Typhoeus::Request.new(
@@ -113,17 +109,16 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_nil $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def test_typhoeus_hydra
-                    $event_list.clear()
                     url = "https://www.google.com?q=test"
                     args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com?q=test", :path=>"", :query=>"q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}}]
                     hydra = Typhoeus::Hydra.hydra
                     request = Typhoeus::Request.new(url)
                     hydra.queue(request)    
-                    response = hydra.run
+                    hydra.run
                     assert_equal 200, request.response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -133,7 +128,7 @@ module NewRelic::Security
                     assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
                     assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
                     assert_nil $event_list[0].parameters[0][:Body]
-                    assert_nil expected_event.eventCategory, $event_list[0].eventCategory
+                    assert_nil $event_list[0].eventCategory
                 end
 
                 def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,31 +1,18 @@
-# test setup
-# Define Log level for logging
+require_relative 'simplecov_test_helper'
+require 'rubygems'
+require 'rake'
+require 'rack'
+require 'rack/handler'
+require 'minitest/autorun'
+require 'minitest/pride' unless ENV['CI']
+
 ENV['NR_CSEC_LOG_LEVEL'] = 'INFO'
-# Define instrumentation method 
 ENV['NR_CSEC_INSTRUMENTATION_METHOD'] = 'prepend'
 
 $: << File.expand_path('../../lib', __FILE__)
 $: << File.expand_path('../../test', __FILE__)
 $:.uniq!
 
-require_relative 'simplecov_test_helper'
-require 'rubygems'
-require 'rake'
-require 'rack'
-require 'rack/handler'
-
-require 'minitest/autorun'
-require 'minitest/pride' unless ENV['CI']
-
-# Define test helper file path
-$test_path = __dir__
-# Declare event list
-$event_list = []
-
-# Loading Security Agent  
-puts "Running tests in Security standalone mode"
-# For now, Can't initialize full security agent, because NR agent is not running.
-# require 'newrelic_security'
 require 'newrelic_security/version.rb'
 require 'newrelic_security/agent/logging/init_logger'
 require 'newrelic_security/agent/logging/logger'
@@ -33,16 +20,23 @@ require 'newrelic_security/agent/configuration/manager'
 require 'newrelic_security/agent/agent'
 require 'newrelic_security/agent/utils/agent_utils'
 require 'newrelic_security/constants'
-
-# loading helper files
-Dir[File.expand_path('../helpers/*', __FILE__)].each { |f| require f }
+require 'helpers/agent_helper'
+require 'helpers/config_helper'
+require 'helpers/event_helper'
+require 'helpers/init_helper'
+require 'helpers/instrument_helper'
+require 'helpers/sample_server'
+require 'helpers/database_helper'
 
 # Create Agent instance
 module NewRelic::Security
+  module Test
+    TEST_PATH = __dir__
+    $event_list = [] #this variable stores the events created for the instrumented methods
+  end
+
   module Agent  
     @agent = NewRelic::Security::Agent::Agent.new
-    @sample_server = Thread.new { ::Rack::Server.start app: SampleServer, Port: 9291 }
+    @sample_server = Thread.new { ::Rack::Server.start app: NewRelic::Security::Test::SampleServer, Port: 9291 }
   end
 end
-
-NewRelic::Security::Agent::Control::HTTPContext.clear_context


### PR DESCRIPTION
Changes: 
- Skipped Typhoeus instrumentation as Typhoeus uses Ethon in the backgroud.
- Added setup and teardown for sqlite3, sqlite3_adapater & Typhoeus tests
- Added nil check
- Remove `Sqlite3::Database.execute2` hook as this always call `Sqlite3::Statement.execute`
- Removed `Sqlite3::Database.prepare` hook
- Added `Sqlite3::Statemet.initialize` hook(this replaces prepare hook)
- Removed @@vars
- event_list clear in setup
- add filter_event method
- Use assert_nil for nil check
- Fix for LDAP tests failing in chain hooking
- Fix for Aysnc-http tests failing in chain hooking
- Created database_helper for all database containers
- Storing database related config on database_helper as constants