### PR TITLE
updated log rollover and probing interval

### DIFF
--- a/lib/newrelic_security/agent/control/iast_client.rb
+++ b/lib/newrelic_security/agent/control/iast_client.rb
@@ -17,6 +17,8 @@ module NewRelic::Security
       IS_GRPC = 'isGrpc'
       INPUT_CLASS = 'inputClass'
       SERVER_PORT_1 = 'serverPort'
+      PROBING = 'probing'
+      INTERVAL = 'interval'
 
       class IASTClient
         
@@ -68,7 +70,7 @@ module NewRelic::Security
           @iast_data_transfer_request_processor_thread = Thread.new do
             Thread.current.name = "newrelic_security_iast_data_transfer_request_processor"
             loop do
-              sleep 1
+              sleep NewRelic::Security::Agent.config[:policy][VULNERABILITY_SCAN][IAST_SCAN][PROBING][INTERVAL]
               current_timestamp = current_time_millis
               cooldown_sleep_time = @cooldown_till_timestamp - current_timestamp
               sleep cooldown_sleep_time/1000 if cooldown_sleep_time > 0

--- a/lib/newrelic_security/agent/logging/logger.rb
+++ b/lib/newrelic_security/agent/logging/logger.rb
@@ -5,7 +5,7 @@ module NewRelic::Security
   module Agent
     module Logging
       LOG_FILE_SIZE = 50 * 1024 * 1024
-      MAX_LOG_FILES = 2
+      MAX_LOG_FILES = 3
 
       class AgentLogger
         def initialize

--- a/lib/newrelic_security/agent/logging/logger.rb
+++ b/lib/newrelic_security/agent/logging/logger.rb
@@ -4,7 +4,8 @@ require 'logger'
 module NewRelic::Security
   module Agent
     module Logging
-      LOG_FILE_NAME = 'ruby-security-collector.log'
+      LOG_FILE_SIZE = 50 * 1024 * 1024
+      MAX_LOG_FILES = 2
 
       class AgentLogger
         def initialize
@@ -34,7 +35,7 @@ module NewRelic::Security
         private
 
         def prepped_logger(target)
-          @logger = ::Logger.new(target)
+          @logger = ::Logger.new(target, MAX_LOG_FILES, LOG_FILE_SIZE)
           @logger.level = AgentLogger.log_level_for(NewRelic::Security::Agent.config[:log_level])
           @logger.instance_variable_set(:@skip_instrumenting, true)
           @logger.freeze

--- a/lib/newrelic_security/agent/utils/agent_utils.rb
+++ b/lib/newrelic_security/agent/utils/agent_utils.rb
@@ -8,9 +8,7 @@ module NewRelic::Security
     module Utils
       extend self
 
-      VULNERABILITY_SCAN = 'vulnerabilityScan'
       ENABLED = 'enabled'
-      IAST_SCAN = 'iastScan'
       VULNERABLE = 'VULNERABLE'
       AES_256_CBC = 'AES-256-CBC'
       H_ASTERIK = 'H*'

--- a/lib/newrelic_security/constants.rb
+++ b/lib/newrelic_security/constants.rb
@@ -10,6 +10,7 @@ module NewRelic::Security
   SEC_HOME_PATH = 'nr-security-home'
   LOGS_DIR = 'logs'
   TMP_DIR = 'tmp'
+  LOG_FILE_NAME = 'ruby-security-collector.log'
   NR_SECURITY_HOME_TMP = 'nr-security-home/tmp/'
   NR_CSEC_FUZZ_REQUEST_ID = 'nr-csec-fuzz-request-id'
   NR_CSEC_TRACING_DATA = 'nr-csec-tracing-data'
@@ -60,4 +61,6 @@ module NewRelic::Security
   CONTENT_TYPE1 = 'content-Type'
   PULL = 'PULL'
   SHA1 = 'sha1'
+  VULNERABILITY_SCAN = 'vulnerabilityScan'
+  IAST_SCAN = 'iastScan'
 end

--- a/lib/newrelic_security/instrumentation-security/io/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/io/chain.rb
@@ -11,12 +11,14 @@ module NewRelic::Security
 
               if RUBY_VERSION < '2.7.0'
                 def open(var1, var2 = "r", *var3, &var4)
+                  return open_without_security(var1, var2, *var3, &var4) if var1.to_s.include?(LOG_FILE_NAME)
                   retval = nil
                   event = open_on_enter(var1, var2) { retval = open_without_security(var1, var2, *var3, &var4) }
                   open_on_exit(event) { return retval }
                 end
               else
                 def open(*args, **kwargs, &block)
+                  return open_without_security(*args, **kwargs, &block) if args[0].to_s.include?(LOG_FILE_NAME)
                   retval = nil
                   event = open_on_enter(*args) { retval = open_without_security(*args, **kwargs, &block) }
                   open_on_exit(event) { return retval }

--- a/lib/newrelic_security/instrumentation-security/io/prepend.rb
+++ b/lib/newrelic_security/instrumentation-security/io/prepend.rb
@@ -5,12 +5,14 @@ module NewRelic::Security
         include NewRelic::Security::Instrumentation::IO
         if RUBY_VERSION < '2.7.0'
           def open(var1, var2 = "r", *var3, &var4)
+            return super if var1.to_s.include?(LOG_FILE_NAME)
             retval = nil
             event = open_on_enter(var1, var2) { retval = super }
             open_on_exit(event) { return retval }
           end
         else
           def open(*args, **kwargs, &block)
+            return super if args[0].to_s.include?(LOG_FILE_NAME)
             retval = nil
             event = open_on_enter(*args) { retval = super }
             open_on_exit(event) { return retval }


### PR DESCRIPTION
- Log rollover:
  - Updated max log files to 2
  - Updated log file size to 50MB
- IAST probing interval change for iast-data-request
  - Updated IAST probing time from policy config received from SE.