### PR TITLE
fix for exec_delete in mysql2 jruby NR-287921

### DIFF
--- a/lib/newrelic_security/instrumentation-security/active_record/mysql2_adapter/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/active_record/mysql2_adapter/chain.rb
@@ -49,6 +49,14 @@ module NewRelic::Security
                       exec_query_on_exit(event) { return retval }
                     end
                   end
+
+                  alias_method :exec_delete_without_security, :exec_delete
+
+                  def exec_delete(*var)
+                    retval = nil
+                    event = exec_delete_on_enter(*var) { retval = exec_delete_without_security(*var) }
+                    exec_delete_on_exit(event) { return retval }
+                  end
                 end
                 
               end

--- a/lib/newrelic_security/instrumentation-security/active_record/mysql2_adapter/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/active_record/mysql2_adapter/instrumentation.rb
@@ -142,6 +142,44 @@ module NewRelic::Security
         yield
       end
 
+      def exec_delete_on_enter(*var, **key_vars)
+        event = nil
+        NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
+        type_casted_binds = []
+        binds = var[2] #third arg
+        if !binds.nil? && !binds.empty? #if bind params present
+          binds.each { |x|
+            if x.is_a? Integer or x.is_a? String
+              type_casted_binds << x
+            elsif x.is_a? Array and x[0].is_a? ::ActiveRecord::ConnectionAdapters::Column
+              type_casted_binds << x[1].to_s
+            else
+              type_casted_binds << x.value_before_type_cast.to_s
+            end
+          }
+          # binds_copy = binds.clone  #it is a shallow copy
+          # type_casted_binds = type_casted_binds(binds_copy.to_s)
+        end
+        hash = {}
+        hash[:sql] = var[0]  #sql query
+        hash[:parameters] = type_casted_binds #bind params
+        event = NewRelic::Security::Agent::Control::Collector.collect(SQL_DB_COMMAND, [hash], MYSQL) unless NewRelic::Security::Instrumentation::InstrumentationUtils.sql_filter_events?(hash[:sql])
+      rescue => exception
+        NewRelic::Security::Agent.logger.error "Exception in hook in #{self.class}.#{__method__}, #{exception.inspect}, #{exception.backtrace}"
+      ensure
+        yield
+        return event
+      end
+
+      def exec_delete_on_exit(event)
+        NewRelic::Security::Agent.logger.debug "OnExit :  #{self.class}.#{__method__}"
+        NewRelic::Security::Agent::Utils.create_exit_event(event)
+      rescue => exception
+        NewRelic::Security::Agent.logger.error "Exception in hook in #{self.class}.#{__method__}, #{exception.inspect}, #{exception.backtrace}"
+      ensure
+        yield
+      end
+
     end
   end
 end

--- a/lib/newrelic_security/instrumentation-security/active_record/mysql2_adapter/prepend.rb
+++ b/lib/newrelic_security/instrumentation-security/active_record/mysql2_adapter/prepend.rb
@@ -38,6 +38,12 @@ module NewRelic::Security
                   exec_query_on_exit(event) { return retval }
                 end
               end
+
+              def exec_delete(*var)
+                retval = nil
+                event = exec_delete_on_enter(*var) { retval = super }
+                exec_delete_on_exit(event) { return retval }
+              end
             end
     
           end

--- a/test/newrelic_security/instrumentation-security/active_record/mysql2_adapter/mysql2_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/mysql2_adapter/mysql2_adapter_test.rb
@@ -104,7 +104,7 @@ module NewRelic::Security
                     # data verify
                     assert_equal 1, output
                     # event verify
-                    args1 = [{:sql=>"DELETE FROM \"new_users\" WHERE \"new_users\".\"id\" = $1", :parameters=>["1"]}]
+                    args1 = [{:sql=>"DELETE FROM `new_users` WHERE `new_users`.`id` = 1", :parameters=>[]}]
                     expected_event1 = NewRelic::Security::Agent::Control::Event.new(SQL_DB_COMMAND, args1, MYSQL)
 
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(SQL_DB_COMMAND)

--- a/test/newrelic_security/instrumentation-security/active_record/mysql2_adapter/mysql2_adapter_test.rb
+++ b/test/newrelic_security/instrumentation-security/active_record/mysql2_adapter/mysql2_adapter_test.rb
@@ -100,7 +100,6 @@ module NewRelic::Security
                     $event_list.clear()
 
                     # DELETE test
-                    skip("Issue in delete case in jruby") if RUBY_ENGINE == 'jruby'
                     output = NewUser.delete(1)
                     # data verify
                     assert_equal 1, output


### PR DESCRIPTION
- fix for SQL event is not generated for delete query in mysql2_adapter in Jruby [NR-287921](https://new-relic.atlassian.net/browse/NR-287921)

[NR-287921]: https://new-relic.atlassian.net/browse/NR-287921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ