### PR TITLE
fix for agent not initialized in EKS env(NR-291892)

### DIFF
--- a/lib/newrelic_security/agent.rb
+++ b/lib/newrelic_security/agent.rb
@@ -49,7 +49,7 @@ module NewRelic::Security
     end
     
     @agent = NewRelic::Security::Agent::Agent.new unless @agent
-    NewRelic::Agent.instance.events.notify(:server_source_configuration_added) if ::Gem.win_platform? && NewRelic::Agent.agent.connected?
+    NewRelic::Agent.instance.events.notify(:server_source_configuration_added) if NewRelic::Agent.agent.connected?
     NewRelic::Security::Agent.logger.debug "Creating security agent instance initially : #{@agent.inspect}"
     NewRelic::Security::Agent.init_logger.info "[STEP-1] => Security agent is starting : #{@agent.inspect}"
     NewRelic::Security::Agent.init_logger.info "[STEP-2] => Generating unique identifier : #{@config[:uuid]}"


### PR DESCRIPTION
- fix for agent not initialized in EKS env [NR-291892](https://new-relic.atlassian.net/browse/NR-291892)

[NR-291892]: https://new-relic.atlassian.net/browse/NR-291892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ