### PR TITLE
Add dependency on `newrelic_rpm`

### DIFF
--- a/newrelic_security.gemspec
+++ b/newrelic_security.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |spec|
   ]
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'newrelic_rpm', '>= 9.12.0'
+
   spec.add_development_dependency 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '~> 5.18' : '4.7.5'}"
 
   spec.add_development_dependency 'rubocop', "#{RUBY_VERSION < '2.6.0' ? '< 1.49.0' : '~> 1.49.0'}"


### PR DESCRIPTION
~~**DO NOT MERGE UNTIL AFTER 9.12.0 is released**~~ 9.12.0 has been released 😄  

This code requires `newrelic_rpm` to run. This change sets a minimum version requirement for compatibility. It will also make sure `newrelic_rpm` is installed if it is not already specified in the Gemfile.