### PR TITLE
fix for NR-295116

### DIFF
--- a/lib/newrelic_security/agent/configuration/manager.rb
+++ b/lib/newrelic_security/agent/configuration/manager.rb
@@ -127,10 +127,10 @@ module NewRelic::Security
 
         def generate_uuid
           if defined?(::Puma::Cluster)
-            ObjectSpace.each_object(::Puma::Cluster) { |z| return fetch_or_create_uuid if !z.preload? && z.instance_variable_get(:@options)[:workers] > 1 }
+            ObjectSpace.each_object(::Puma::Cluster) { |z| return fetch_or_create_uuid if !z.preload? && z.instance_variable_get(:@options)[:workers] >= 1 }
           end
           if defined?(::Unicorn::HttpServer)
-            ObjectSpace.each_object(::Unicorn::HttpServer) { |z| return fetch_or_create_uuid if !z.preload_app && z.worker_processes > 1 }
+            ObjectSpace.each_object(::Unicorn::HttpServer) { |z| return fetch_or_create_uuid if !z.preload_app && z.worker_processes >= 1 }
           end
           if defined?(::PhusionPassenger::App) && ::PhusionPassenger::App.options[SPAWN_METHOD].match?(/#{DIRECT}/i)
             return create_uuid


### PR DESCRIPTION
- Fix for New appuuid is generated for the new worker when the old worker dies in Unicorn app [NR-295116](https://new-relic.atlassian.net/browse/NR-295116)

[NR-295116]: https://new-relic.atlassian.net/browse/NR-295116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ