### PR TITLE
Update ssrf parameters

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -73,5 +73,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
           failedThreshold: 70
-          failedThresholdBranch: 33
+          failedThresholdBranch: 30
 

--- a/lib/newrelic_security/agent/configuration/manager.rb
+++ b/lib/newrelic_security/agent/configuration/manager.rb
@@ -39,7 +39,7 @@ module NewRelic::Security
           @cache[:listen_port] = nil
           @cache[:app_root] = NewRelic::Security::Agent::Utils.app_root
           @cache[:jruby_objectspace_enabled] = false
-          @cache[:json_version] = :'1.2.4'
+          @cache[:json_version] = :'1.2.8'
 
           @environment_source = NewRelic::Security::Agent::Configuration::EnvironmentSource.new
           @server_source = NewRelic::Security::Agent::Configuration::ServerSource.new

--- a/lib/newrelic_security/instrumentation-security/async-http/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/async-http/instrumentation.rb
@@ -6,22 +6,11 @@ module NewRelic::Security
   module Instrumentation
     module AsyncHttp
 
-      def call_on_enter(method, url, headers, body)
+      def call_on_enter(_method, url, headers, _body)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = method
         uri = ::URI.parse url
-        ob[:scheme]  = uri.scheme
-        ob[:host]    = uri.host
-        ob[:port]    = uri.port
-        ob[:URI]     = uri.to_s
-        ob[:path]    = uri.path
-        ob[:query]   = uri.query
-        ob[:Body] = body.respond_to?(:join) ? body.join.to_s : body.to_s
-        ob[:Headers] = headers.to_h
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri.to_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.append_tracing_data(headers, event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/curb/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/curb/instrumentation.rb
@@ -12,20 +12,7 @@ module NewRelic::Security
         self.requests.each {
           |key, req|
           uri = NewRelic::Security::Instrumentation::InstrumentationUtils.parse_uri(req.url)
-          ob = {}
-          if uri
-            ob[:Method]  = nil
-            ob[:scheme]  = uri.scheme
-            ob[:host]    = uri.host
-            ob[:port]    = uri.port
-            ob[:URI]     = uri.to_s
-            ob[:path]    = uri.path
-            ob[:query]   = uri.query
-            ob[:Body]    = req.post_body
-            ob[:Headers] = req.headers
-            ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-            ic_args.push(ob)
-          end
+          ic_args.push(uri.to_s) if uri
         }
         event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, ic_args)
         self.requests.each { |key, req| NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(req.headers, event) } if event

--- a/lib/newrelic_security/instrumentation-security/ethon/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/ethon/chain.rb
@@ -7,12 +7,6 @@ module NewRelic::Security
             ::Ethon::Easy.class_eval do
               include NewRelic::Security::Instrumentation::Ethon::Easy
 
-              alias_method :fabricate_without_security, :fabricate
-    
-              def fabricate(url, action_name, options)
-                fabricate_on_enter(url, action_name, options) { return fabricate_without_security(url, action_name, options) }
-              end
-
               alias_method(:headers_equals_without_security, :headers=)
     
               def headers=(headers)

--- a/lib/newrelic_security/instrumentation-security/ethon/prepend.rb
+++ b/lib/newrelic_security/instrumentation-security/ethon/prepend.rb
@@ -4,10 +4,6 @@ module NewRelic::Security
       module Easy
         module Prepend
           include NewRelic::Security::Instrumentation::Ethon::Easy
-
-          def fabricate(url, action_name, options)
-            fabricate_on_enter(url, action_name, options) { return super }
-          end
   
           def headers=(headers)
             headers_equals_on_enter(headers) { return super }

--- a/lib/newrelic_security/instrumentation-security/excon/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/excon/instrumentation.rb
@@ -5,21 +5,11 @@ module NewRelic::Security
   module Instrumentation
     module Excon::Connection
 
-      def request_on_enter(params)
+      def request_on_enter(_params)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = params[:method]
-        ob[:scheme]  = self.data[:scheme]
-        ob[:host]    = self.data[:host]
-        ob[:port]    = self.data[:port]
-        ob[:URI]     = self.data[:query].nil? ? "#{self.data[:host]}#{self.data[:path]}" : "#{self.data[:host]}#{self.data[:path]}?#{self.data[:query]}"
-        ob[:path]    = self.data[:path]
-        ob[:query]   = self.data[:query]
-        ob[:Body] = self.data[:body]
-        ob[:Headers] = self.data[:headers]
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        uri = "#{self.data[:scheme]}://#{self.data[:host]}#{self.data[:path]}"
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(self.data[:headers], event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/httpclient/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/httpclient/instrumentation.rb
@@ -8,20 +8,8 @@ module NewRelic::Security
       def do_request_on_enter(method, uri, query, body, header)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = method
-        unless uri.nil?
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-        end
-        ob[:Body] = body
-        ob[:Headers] = header
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        uri_s = uri.to_s unless uri.nil?
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(header, event) if event
         event
       rescue => exception
@@ -43,20 +31,8 @@ module NewRelic::Security
       def do_request_async_on_enter(method, uri, query, body, header)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = method
-        unless uri.nil?
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-        end
-        ob[:Body] = body
-        ob[:Headers] = header
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        uri_s = uri.to_s unless uri.nil?
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(header, event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/httprb/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/httprb/instrumentation.rb
@@ -8,19 +8,8 @@ module NewRelic::Security
       def perform_on_enter(request, options)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-				ob[:Method] = request.verb
-        ob[:scheme] = request.scheme
-        ob[:host] = request.uri.host
-        ob[:port] = request.uri.port
-        ob[:URI] = request.uri.to_s
-        ob[:path] = request.uri.path
-        ob[:query] = request.uri.query
-        ob[:Body] = request.body.source.to_s
-        ob[:Headers] = options.headers.to_h
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [request.uri.to_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(options.headers, event) if event
-        ob = nil
         event
       rescue => exception
         NewRelic::Security::Agent.logger.error "Exception in hook in #{self.class}.#{__method__}, #{exception.inspect}, #{exception.backtrace}"

--- a/lib/newrelic_security/instrumentation-security/httpx/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/httpx/instrumentation.rb
@@ -9,21 +9,7 @@ module NewRelic::Security
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
         ic_args = []
-        args.each do |arg|
-          ob = {}
-          ob[:Method] = arg.verb
-          uri = arg.uri
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-          ob[:Body]    = arg.body.bytesize.positive? ? arg.body.to_s : ""
-          ob[:Headers] = arg.headers
-          ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-          ic_args << ob
-        end
+        args.each { |arg| ic_args << arg.uri.to_s }
         event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, ic_args)
         args.each do |arg|
           NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(arg.headers, event) if event

--- a/lib/newrelic_security/instrumentation-security/instrumentation_utils.rb
+++ b/lib/newrelic_security/instrumentation-security/instrumentation_utils.rb
@@ -143,23 +143,6 @@ module NewRelic::Security
         return nil
       end
 
-      def parse_typhoeus_request(request)
-        ob = {}
-        ob[:Method] = request.options[:method].nil? ? :get : request.options[:method]
-        ob[:URI] = request.base_url
-        ob[:Body] = request.options[:body]
-        ob[:Headers] = request.options[:headers]
-        uri_parsed = parse_uri(request.base_url)
-        if !uri_parsed.nil?
-          ob[:scheme] = uri_parsed.scheme
-          ob[:host] = uri_parsed.host
-          ob[:port] = uri_parsed.port
-          ob[:path] = uri_parsed.path
-          ob[:query] = uri_parsed.query
-        end
-        ob
-      end
-
     end
   end
 end

--- a/lib/newrelic_security/instrumentation-security/patron/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/patron/instrumentation.rb
@@ -7,25 +7,12 @@ module NewRelic::Security
   module Instrumentation
     module Patron::Session
 
-      def request_on_enter(action, url, headers, options)
+      def request_on_enter(_action, url, headers, _options)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = action
         final_url = self.base_url.nil? ? url : "#{self.base_url}#{url}"
         uri = NewRelic::Security::Instrumentation::InstrumentationUtils.parse_uri(final_url)
-        if uri
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-          ob[:Body] = options[:data]
-          ob[:Headers] = headers
-          ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-          event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
-        end
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri.to_s]) if uri
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(headers, event) if event
         event
       rescue => exception

--- a/test/newrelic_security/instrumentation-security/async-http/async_http_test.rb
+++ b/test/newrelic_security/instrumentation-security/async-http/async_http_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Security
                 end
 
                 def test_get
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com/search?q=test", :path=>"/search", :query=>"q=test", :Body=>"", :Headers=>{"accept"=>"application/json"}}]
+                    args = ["http://www.google.com/search?q=test"]
                     response = nil
                     Async do
                         begin
@@ -26,23 +26,19 @@ module NewRelic::Security
                         ensure
                             internet.close
                         end
-                        # TODO: Ensure without begin/end supported after RUBY_VERSION >= 2.5, remove rescue to optimize.
+                      # TODO: Ensure without begin/end supported after RUBY_VERSION >= 2.5, remove rescue to optimize.
                     end
                     assert_equal 200, response.status
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 if RUBY_VERSION >= '2.5.0'
                     def test_get_ssl
-                        args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/search?q=test", :path=>"/search", :query=>"q=test", :Body=>"", :Headers=>{"accept"=>"application/json"}}]
+                        args = ["https://www.google.com/search?q=test"]
                         response = nil
                         Async do
                             begin
@@ -59,18 +55,14 @@ module NewRelic::Security
                         expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                         assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                         assert_equal expected_event.caseType, $event_list[0].caseType
-                        assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                        assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                        assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                        assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                        assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                        assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                         assert_nil $event_list[0].eventCategory
                     end
                 end
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>"POST", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books"]
                     data = {"title"=>"New", "author"=>"New Author"}
                     response = nil
                     Async do
@@ -90,18 +82,14 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"PUT", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
-                    data = {"title"=>"Update Book","author"=>"Update Author"}
+                    args = ["http://localhost:9291/books/1"]
+                    data = {"title"=>"Update Book", "author"=>"Update Author"}
                     response = nil
                     Async do
                         begin
@@ -120,17 +108,13 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"DELETE", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = nil
                     Async do
                         begin
@@ -147,11 +131,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 

--- a/test/newrelic_security/instrumentation-security/curb/curb_test.rb
+++ b/test/newrelic_security/instrumentation-security/curb/curb_test.rb
@@ -8,7 +8,7 @@ module NewRelic::Security
         module Instrumentation
             class TestCurb < Minitest::Test
                 TEST_URL = "https://www.google.com"
-                ARGS = [{:Method=>nil, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                ARGS = ["https://www.google.com"]
 
                 def setup
                     $event_list.clear()

--- a/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
+++ b/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
@@ -14,7 +14,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil}]
+                    args = ["https://www.google.com"]
                     easy = Ethon::Easy.new(url: url)
                     response = easy.perform
                     @output = response
@@ -28,7 +28,7 @@ module NewRelic::Security
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = [{:scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil}]
+                    args = ["https://www.google.com"]
                     easy = Ethon::Easy.new(url: url)
                     response = easy.perform
                     @output = response
@@ -42,7 +42,7 @@ module NewRelic::Security
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>:post, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\" : \"New Book\", \"author\": \"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books"]
                     # response = HTTPX.post(url, :json => {:name => "testuser", :salary => "123", :age => "23"})
                     easy = Ethon::Easy.new
                     easy.http_request(url, :post, body: '{"title" : "New Book", "author": "New Author"}')
@@ -58,7 +58,7 @@ module NewRelic::Security
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:put, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\": \"Update Book\", \"author\": \"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books/1"]
                     # response = HTTPX.put(url, :json => {:name => "testuser", :salary => "123",:age => "23"})
                     easy = Ethon::Easy.new
                     easy.http_request(url, :put, { body: '{"title": "Update Book", "author": "Update Author"}'})
@@ -74,7 +74,7 @@ module NewRelic::Security
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:delete, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>nil, :Headers=>{"User-Agent"=>"ethon"}}]
+                    args = ["http://localhost:9291/books/1"]
                     # response = HTTPX.delete(url)
                     easy = Ethon::Easy.new
                     easy.http_request(url, :delete)
@@ -102,7 +102,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:Method=>:get, :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>nil}, {:Method=>:get, :scheme=>"https", :host=>"newrelic.com", :port=>443, :URI=>"https://newrelic.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"User-Agent"=>"ethon"}}]
+                    args = ["http://www.google.com", "https://newrelic.com"]
 
                     multi = Ethon::Multi.new
                     easy = Ethon::Easy.new

--- a/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
+++ b/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
@@ -14,7 +14,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = ["https://www.google.com"]
+                    args = ["http://www.google.com"]
                     easy = Ethon::Easy.new(url: url)
                     response = easy.perform
                     @output = response

--- a/test/newrelic_security/instrumentation-security/excon/excon_test.rb
+++ b/test/newrelic_security/instrumentation-security/excon/excon_test.rb
@@ -16,17 +16,10 @@ module NewRelic::Security
                     skip("Skipping for ruby 2.4.10 && instrumentation method chain") if RUBY_VERSION == '2.4.10' && ENV['NR_CSEC_INSTRUMENTATION_METHOD'] == 'chain'
                     url = "http://google.com"
                     @output = Excon.get(url).body
-                    args = [{:Method=>:get, :scheme=>"http", :host=>"google.com", :port=>80, :URI=>"google.com", :path=>"", :query=>nil, :Body=>nil}]
+                    args = ["http://google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:host], $event_list[0].parameters[0][:host]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:path], $event_list[0].parameters[0][:path]
-                    assert_nil $event_list[0].parameters[0][:query]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
                 

--- a/test/newrelic_security/instrumentation-security/httpclient/httpclient_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpclient/httpclient_test.rb
@@ -16,7 +16,7 @@ module NewRelic::Security
                     client = HTTPClient.new
 	                @output = client.get_content(url)
                     #puts @output
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -29,7 +29,7 @@ module NewRelic::Security
                     client = HTTPClient.new
                     method = 'GET'
                     assert_equal 200, client.request(method, url).code
-                    args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -41,7 +41,7 @@ module NewRelic::Security
                     url = "https://www.google.com"
                     client = HTTPClient.new
                     assert_equal 200, client.get(url, :follow_redirect => true).code
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -53,7 +53,7 @@ module NewRelic::Security
                     url = "https://www.google.com"
                     client = HTTPClient.new
                     assert_equal 200, client.head(url).code
-                    args = [{:Method=>:head, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -72,7 +72,7 @@ module NewRelic::Security
                     @output = str
                     #puts @output
                     #assert_equal 200, @output 
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
+++ b/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = ["http://www.google.com"]
+                    args = ["http://www.google.com/?foo=bar"]
                     response = HTTP.headers({"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
@@ -25,7 +25,7 @@ module NewRelic::Security
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = ["http://www.google.com"]
+                    args = ["https://www.google.com/?foo=bar"]
                     response = HTTP.headers({"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)

--- a/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
+++ b/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
@@ -14,7 +14,7 @@ module NewRelic::Security
                 def test_get
                     url = "http://www.google.com"
                     args = ["http://www.google.com"]
-                    response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
+                    response = HTTP.headers({"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -26,7 +26,7 @@ module NewRelic::Security
                 def test_get_ssl
                     url = "https://www.google.com"
                     args = ["http://www.google.com"]
-                    response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
+                    response = HTTP.headers({"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -38,7 +38,7 @@ module NewRelic::Security
                 def test_post_json
                     url = "http://localhost:9291/books"
                     args = ["http://localhost:9291/books"]
-                    response = HTTP.headers(args[0][:Headers]).post(url, :json => {:title => "New", :author => "New Author"})
+                    response = HTTP.headers({"Content-Type"=>"application/json"}).post(url, :json => {:title => "New", :author => "New Author"})
                     assert_equal 201, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -50,7 +50,7 @@ module NewRelic::Security
                 def test_put_json
                     url = "http://localhost:9291/books/1"
                     args = ["http://localhost:9291/books/1"]
-                    response = HTTP.headers(args[0][:Headers]).put(url, :json => {:title => "Update Book", :author => "Update Author"})
+                    response = HTTP.headers({"Content-Type"=>"application/json"}).put(url, :json => {:title => "Update Book", :author => "Update Author"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)

--- a/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
+++ b/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:Method=>:get, :scheme=>:http, :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com/?foo=bar", :path=>"/", :query=>"foo=bar", :Body=>"", :Headers=>{"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}}]
+                    args = ["http://www.google.com"]
                     response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
@@ -25,7 +25,7 @@ module NewRelic::Security
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = [{:Method=>:get, :scheme=>:https, :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/?foo=bar", :path=>"/", :query=>"foo=bar", :Body=>"", :Headers=>{"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}}]
+                    args = ["http://www.google.com"]
                     response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
@@ -37,8 +37,8 @@ module NewRelic::Security
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>:post, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
-                    response = HTTP.headers(args[0][:Headers]).post(url, :json => {:title => "New", :author => "New Author"} )
+                    args = ["http://localhost:9291/books"]
+                    response = HTTP.headers(args[0][:Headers]).post(url, :json => {:title => "New", :author => "New Author"})
                     assert_equal 201, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -49,7 +49,7 @@ module NewRelic::Security
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:put, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = HTTP.headers(args[0][:Headers]).put(url, :json => {:title => "Update Book", :author => "Update Author"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
@@ -61,7 +61,7 @@ module NewRelic::Security
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:delete, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = HTTP.delete(url)
                     assert_equal 204, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)

--- a/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://www.google.com"]
                     response = HTTPX.get(url)
                     @output = response.status
                     assert_equal 200, @output
@@ -30,7 +30,7 @@ module NewRelic::Security
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     response = HTTPX.get(url)
                     @output = response.status
                     assert_equal 200, @output
@@ -47,8 +47,8 @@ module NewRelic::Security
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>"POST", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{}}]
-                    response = HTTPX.post(url, :json => {"title"=>"New","author"=>"New Author"})
+                    args = ["http://localhost:9291/books"]
+                    response = HTTPX.post(url, :json => {"title"=>"New", "author"=>"New Author"})
                     @output = response.status
                     assert_equal 201, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
@@ -64,8 +64,8 @@ module NewRelic::Security
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"PUT", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{}}]
-                    response = HTTPX.put(url, :json => {"title"=>"Update Book","author"=>"Update Author"})
+                    args = ["http://localhost:9291/books/1"]
+                    response = HTTPX.put(url, :json => {"title"=>"Update Book", "author"=>"Update Author"})
                     @output = response.status
                     assert_equal 200, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
@@ -81,7 +81,7 @@ module NewRelic::Security
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"DELETE", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = HTTPX.delete(url)
                     @output = response.status
                     assert_equal 204, @output

--- a/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
@@ -20,11 +20,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
@@ -37,11 +33,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
@@ -54,11 +46,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
@@ -71,11 +59,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
@@ -88,11 +72,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 

--- a/test/newrelic_security/instrumentation-security/net_http/net_http_test.rb
+++ b/test/newrelic_security/instrumentation-security/net_http/net_http_test.rb
@@ -25,7 +25,7 @@ module NewRelic::Security
                     request = Net::HTTP::Get.new(uri.request_uri)
                     response = http.request(request)
                     assert_equal "200", response.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"close"}}]
+                    args = ["http://www.google.com:80/"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -38,7 +38,7 @@ module NewRelic::Security
                     uri = URI(url)
                     @output = Net::HTTP.get(uri)
                     #puts @output
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -53,7 +53,7 @@ module NewRelic::Security
 	                uri.query = URI.encode_www_form(uri_params)
                     @output = Net::HTTP.get_response(uri)
                     assert_equal "200", @output.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com?limit=10&page=3", :path=>"", :query=>"limit=10&page=3", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com?limit=10&page=3"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -70,7 +70,7 @@ module NewRelic::Security
                         @output = http.request(request)
                     end
                     assert_equal "200", @output.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -86,7 +86,7 @@ module NewRelic::Security
                         @output = http.request(request)
                     end
                     assert_equal "200", @output.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -101,7 +101,7 @@ module NewRelic::Security
                     response = http.request(uri)
                     @output = response.code
                     assert_equal "200", @output
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"keep-alive", "keep-alive"=>"30"}}]
+                    args = ["http://www.google.com:80/"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/patron/patron_test.rb
+++ b/test/newrelic_security/instrumentation-security/patron/patron_test.rb
@@ -19,7 +19,7 @@ module NewRelic::Security
                                             :headers => {'User-Agent' => 'myapp/1.0'} } )
                     @output = sess.get("/").body
                     #puts @output
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/", :path=>"/", :query=>nil, :Body=>nil, :Headers=>{"Expect"=>""}}]
+                    args = ["https://www.google.com/"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/typhoeus/typhoeus_test.rb
+++ b/test/newrelic_security/instrumentation-security/typhoeus/typhoeus_test.rb
@@ -14,107 +14,87 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com?q=test"
-                    args = [{:Method=>:get, :URI=>"http://www.google.com?q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}, :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"", :query=>"q=test"}]
+                    args = ["http://www.google.com?q=test"]
                     response = Typhoeus.get(url) # input=https://www.google.com
                     assert_equal 200, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
                     url = "https://www.google.com?q=test"
-                    args = [{:Method=>:get, :URI=>"https://www.google.com?q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}, :scheme=>"https", :host=>"www.google.com", :port=>443, :path=>"", :query=>"q=test"}]
+                    args = ["https://www.google.com?q=test"]
                     response = Typhoeus.get(url) # input=https://www.google.com
                     assert_equal 200, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>:post, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books?field1=a%20field", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{:"Content-Type"=>"application/json"}}]
-                    data = {"title"=>"New","author"=>"New Author"}
+                    args = ["http://localhost:9291/books?field1=a%20field"]
+                    data = {"title"=>"New", "author"=>"New Author"}
                     request = Typhoeus::Request.new(
-                        url,
-                        method: :post,
-                        body: data.to_json,
-                        params: { field1: "a field" },
-                        headers: { "Content-Type": "application/json" }
+                      url,
+                      method: :post,
+                      body: data.to_json,
+                      params: { field1: "a field" },
+                      headers: { 'Content-Type': "application/json" }
                     )
                     response = request.run
                     assert_equal 201, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:put, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1?field1=a%20field", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{:"Content-Type"=>"application/json"}}]
-                    data = {"title"=>"Update Book","author"=>"Update Author"}
+                    args = ["http://localhost:9291/books/1?field1=a%20field"]
+                    data = {"title"=>"Update Book", "author"=>"Update Author"}
                     request = Typhoeus::Request.new(
-                        url,
-                        method: :put,
-                        body: data.to_json,
-                        params: { field1: "a field" },
-                        headers: { "Content-Type": "application/json" }
+                      url,
+                      method: :put,
+                      body: data.to_json,
+                      params: { field1: "a field" },
+                      headers: { 'Content-Type': "application/json" }
                     )
                     response = request.run
                     assert_equal 200, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:delete, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/api/v1/delete/1", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     request = Typhoeus::Request.new(
-                        url,
-                        method: :delete
+                      url,
+                      method: :delete
                     )
                     response = request.run
                     assert_equal 204, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_typhoeus_hydra
                     url = "https://www.google.com?q=test"
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com?q=test", :path=>"", :query=>"q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}}]
+                    args = ["https://www.google.com?q=test"]
                     hydra = Typhoeus::Hydra.hydra
                     request = Typhoeus::Request.new(url)
                     hydra.queue(request)    
@@ -123,11 +103,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 


### PR DESCRIPTION
### Updated json_version to 1.2.8
### Updated the parameters in SSRF events to follow the structure of other security agents.
Earlier the parameters looked like this: `parameters: [{"URI1": "", "method":"GET"...}, {"URI1": "", "method":"GET"}]`
Now parameters looks like: `parameters: ["URI1", "URI2"]`
Updated the schema for following HTTP clients:
-  Async::HTTP
- Curb
- Ethon
- Excon
- HttpClient
- HttpRb
- HTTPX
- Net::HTTP
- Patron

Removed `fabricate` method from `ethon` instrumentation as method and body are not required in ssrf parameters
Updated unit tests for all HTTP clients.

