### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -72,6 +72,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
-          failedThreshold: 70
-          failedThresholdBranch: 30
+          failedThreshold: 67
+          failedThresholdBranch: 25
 

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -73,5 +73,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
           failedThreshold: 70
-          failedThresholdBranch: 33
+          failedThresholdBranch: 30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,71 @@
 # New Relic Ruby Security Agent Release Notes
 
+## v0.3.0
+
+Version 0.3.0 introduces more control on IAST scanning through new configs(exclude_from_iast_scan, scan_schedule & scan_controllers) and 
+features like API inventory for gRPC server and IAST scan start related timestamps.
+
+Updated json_version: **1.2.8**
+
+- Feature: IAST scan exclusion for apis, http request parameters(header, query & body) & IAST detection categories and scan scheduling through delay, duration & cron schedule. [PR#131](https://github.com/newrelic/csec-ruby-agent/pull/131)
+
+- Feature: IAST scan request rate limit to control IAST scan request firing. [PR#132](https://github.com/newrelic/csec-ruby-agent/pull/132)
+
+- Feature: API endpoints support for gRPC server applications. [PR#143](https://github.com/newrelic/csec-ruby-agent/pull/143)
+
+- Feature: Reporting of IAST scanning application procStartTime, trafficStartedTime & scanStartTime. [PR#136](https://github.com/newrelic/csec-ruby-agent/pull/136)
+
+- Misc Chore: Optimised SSRF events parameters to send only URL in parameters. [PR#129](https://github.com/newrelic/csec-ruby-agent/pull/129)
+
+##### New security configs
+
+```yaml
+security:
+  exclude_from_iast_scan:
+    api: []
+    http_request_parameters:
+      header: []
+      query: []
+      body: []
+    iast_detection_category:
+      insecure_settings: false
+      invalid_file_access: false
+      sql_injection: false
+      nosql_injection: false
+      ldap_injection: false
+      javascript_injection: false
+      command_injection: false
+      xpath_injection: false
+      ssrf: false
+      rxss: false
+  scan_schedule:
+    delay: 0
+    duration: 0
+    schedule: ""
+    always_sample_traces: false
+  scan_controllers:
+    iast_scan_request_rate_limit: 3600
+```
+
+##### Deprecated security configs (will be removed in next major release v1.0.0)
+```yaml
+security:
+  request:
+    body_limit: 300
+  detection:
+    rci:
+      enabled: true
+    rxss:
+      enabled: true
+    deserialization:
+      enabled: true
+```
+
 ## v0.2.0
 
 Version 0.2.0 introuduces Error reporting as part of security. Any unhandled or 5xx errors in application runtime will now be visible in IAST capability UI. Updated json_version: **1.2.4**
 
-- Feature: Unhandled and 5xx error reproting [PR#134](https://github.com/newrelic/csec-ruby-agent/pull/134)
+- Feature: Unhandled and 5xx error reporting [PR#134](https://github.com/newrelic/csec-ruby-agent/pull/134)
 
 - Bugfix: Fix for API route not present in rails7 [PR#127](https://github.com/newrelic/csec-ruby-agent/pull/127)
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -34,3 +34,11 @@ Distributed under the following license(s):
 
   * [The MIT License](http://opensource.org/licenses/MIT)
 
+
+## [parse-cron](https://github.com/siebertm/parse-cron)
+
+Copyright (C) 2013 Michael Siebert
+
+Distributed under the following license(s):
+
+  * [The MIT License](http://opensource.org/licenses/MIT)

--- a/lib/newrelic_security/agent/configuration/manager.rb
+++ b/lib/newrelic_security/agent/configuration/manager.rb
@@ -39,6 +39,9 @@ module NewRelic::Security
           @cache[:framework] = detect_framework
           @cache[:'security.application_info.port'] = ::NewRelic::Agent.config[:'security.application_info.port'].to_i
           @cache[:listen_port] = nil
+          @cache[:process_start_time] = current_time_millis # TODO: Ruby doesn't provide process start time in pure ruby implementation using agent loading time for now.
+          @cache[:traffic_start_time] = nil
+          @cache[:scan_start_time] = nil
           @cache[:app_root] = NewRelic::Security::Agent::Utils.app_root
           @cache[:jruby_objectspace_enabled] = false
           @cache[:json_version] = :'1.2.8'
@@ -111,6 +114,14 @@ module NewRelic::Security
 
         def update_port=(listen_port)
           @cache[:listen_port] = listen_port
+        end
+
+        def traffic_start_time=(traffic_start_time)
+          @cache[:traffic_start_time] = traffic_start_time
+        end
+
+        def scan_start_time=(scan_start_time)
+          @cache[:scan_start_time] = scan_start_time
         end
 
         def app_server=(app_server)
@@ -190,6 +201,10 @@ module NewRelic::Security
 
         def generate_key(entity_guid)
           ::OpenSSL::PKCS5.pbkdf2_hmac(entity_guid, entity_guid[0..15], 1024, 32, SHA1)
+        end
+
+        def current_time_millis
+          (Time.now.to_f * 1000).to_i
         end
 
         def convert_to_regexp_list(value_list)

--- a/lib/newrelic_security/agent/configuration/manager.rb
+++ b/lib/newrelic_security/agent/configuration/manager.rb
@@ -39,7 +39,7 @@ module NewRelic::Security
           @cache[:listen_port] = nil
           @cache[:app_root] = NewRelic::Security::Agent::Utils.app_root
           @cache[:jruby_objectspace_enabled] = false
-          @cache[:json_version] = :'1.2.4'
+          @cache[:json_version] = :'1.2.8'
 
           @environment_source = NewRelic::Security::Agent::Configuration::EnvironmentSource.new
           @server_source = NewRelic::Security::Agent::Configuration::ServerSource.new

--- a/lib/newrelic_security/agent/configuration/manager.rb
+++ b/lib/newrelic_security/agent/configuration/manager.rb
@@ -27,12 +27,14 @@ module NewRelic::Security
           @cache[:log_level] = ::NewRelic::Agent.config[:log_level]
           @cache[:high_security] = ::NewRelic::Agent.config[:high_security]
           @cache[:'agent.enabled'] = ::NewRelic::Agent.config[:'security.agent.enabled']
-          @cache[:enabled] = ::NewRelic::Agent.config[:'security.enabled']
+          @cache[:'security.enabled'] = ::NewRelic::Agent.config[:'security.enabled']
+          @cache[:enabled] = false
           @cache[:mode] = ::NewRelic::Agent.config[:'security.mode']
           @cache[:validator_service_url] = ::NewRelic::Agent.config[:'security.validator_service_url']
-          @cache[:'security.detection.rci.enabled'] = ::NewRelic::Agent.config[:'security.detection.rci.enabled']
-          @cache[:'security.detection.rxss.enabled'] = ::NewRelic::Agent.config[:'security.detection.rxss.enabled']
-          @cache[:'security.detection.deserialization.enabled'] = ::NewRelic::Agent.config[:'security.detection.deserialization.enabled']
+          # TODO: Remove security.detection.* & security.request.body_limit in next major release
+          @cache[:'security.detection.rci.enabled'] = ::NewRelic::Agent.config[:'security.detection.rci.enabled'].nil? ? true : ::NewRelic::Agent.config[:'security.detection.rci.enabled']
+          @cache[:'security.detection.rxss.enabled'] = ::NewRelic::Agent.config[:'security.detection.rxss.enabled'].nil? ? true : ::NewRelic::Agent.config[:'security.detection.rxss.enabled']
+          @cache[:'security.detection.deserialization.enabled'] = ::NewRelic::Agent.config[:'security.detection.deserialization.enabled'].nil? ? true : ::NewRelic::Agent.config[:'security.detection.deserialization.enabled']
           @cache[:'security.scan_controllers.iast_scan_request_rate_limit'] = ::NewRelic::Agent.config[:'security.scan_controllers.iast_scan_request_rate_limit'].to_i
           @cache[:framework] = detect_framework
           @cache[:'security.application_info.port'] = ::NewRelic::Agent.config[:'security.application_info.port'].to_i
@@ -40,6 +42,24 @@ module NewRelic::Security
           @cache[:app_root] = NewRelic::Security::Agent::Utils.app_root
           @cache[:jruby_objectspace_enabled] = false
           @cache[:json_version] = :'1.2.8'
+          @cache[:'security.exclude_from_iast_scan.api'] = convert_to_regexp_list(::NewRelic::Agent.config[:'security.exclude_from_iast_scan.api'])
+          @cache[:'security.exclude_from_iast_scan.http_request_parameters.header'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.http_request_parameters.header']
+          @cache[:'security.exclude_from_iast_scan.http_request_parameters.query'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.http_request_parameters.query']
+          @cache[:'security.exclude_from_iast_scan.http_request_parameters.body'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.http_request_parameters.body']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.insecure_settings'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.insecure_settings']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.sql_injection'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.sql_injection']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.nosql_injection'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.nosql_injection']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.ldap_injection'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.ldap_injection']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.javascript_injection'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.javascript_injection']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.command_injection'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.command_injection']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.xpath_injection'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.xpath_injection']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.ssrf'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.ssrf']
+          @cache[:'security.exclude_from_iast_scan.iast_detection_category.rxss'] = ::NewRelic::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.rxss']
+          @cache[:'security.scan_schedule.delay'] = ::NewRelic::Agent.config[:'security.scan_schedule.delay'].to_i
+          @cache[:'security.scan_schedule.duration'] = ::NewRelic::Agent.config[:'security.scan_schedule.duration'].to_i
+          @cache[:'security.scan_schedule.schedule'] = ::NewRelic::Agent.config[:'security.scan_schedule.schedule']
+          @cache[:'security.scan_schedule.always_sample_traces'] = ::NewRelic::Agent.config[:'security.scan_schedule.always_sample_traces']
 
           @environment_source = NewRelic::Security::Agent::Configuration::EnvironmentSource.new
           @server_source = NewRelic::Security::Agent::Configuration::ServerSource.new
@@ -170,6 +190,15 @@ module NewRelic::Security
 
         def generate_key(entity_guid)
           ::OpenSSL::PKCS5.pbkdf2_hmac(entity_guid, entity_guid[0..15], 1024, 32, SHA1)
+        end
+
+        def convert_to_regexp_list(value_list)
+          value_list.map do |value|
+            next unless value && !value.empty?
+            value = "^#{value}" if value[0] != '^'
+            value = "#{value}$" if value[-1] != '$'
+            /#{value}/
+          end
         end
       end
     end

--- a/lib/newrelic_security/agent/configuration/manager.rb
+++ b/lib/newrelic_security/agent/configuration/manager.rb
@@ -33,9 +33,9 @@ module NewRelic::Security
           @cache[:'security.detection.rci.enabled'] = ::NewRelic::Agent.config[:'security.detection.rci.enabled']
           @cache[:'security.detection.rxss.enabled'] = ::NewRelic::Agent.config[:'security.detection.rxss.enabled']
           @cache[:'security.detection.deserialization.enabled'] = ::NewRelic::Agent.config[:'security.detection.deserialization.enabled']
+          @cache[:'security.scan_controllers.iast_scan_request_rate_limit'] = ::NewRelic::Agent.config[:'security.scan_controllers.iast_scan_request_rate_limit'].to_i
           @cache[:framework] = detect_framework
           @cache[:'security.application_info.port'] = ::NewRelic::Agent.config[:'security.application_info.port'].to_i
-          @cache[:'security.request.body_limit'] = ::NewRelic::Agent.config[:'security.request.body_limit'].to_i > 0 ? ::NewRelic::Agent.config[:'security.request.body_limit'].to_i : 300
           @cache[:listen_port] = nil
           @cache[:app_root] = NewRelic::Security::Agent::Utils.app_root
           @cache[:jruby_objectspace_enabled] = false

--- a/lib/newrelic_security/agent/control/collector.rb
+++ b/lib/newrelic_security/agent/control/collector.rb
@@ -19,6 +19,8 @@ module NewRelic::Security
         def collect(case_type, args, event_category = nil, **keyword_args)
           return unless NewRelic::Security::Agent.config[:enabled]
           return if NewRelic::Security::Agent::Control::HTTPContext.get_context.nil? && NewRelic::Security::Agent::Control::GRPCContext.get_context.nil?
+          return if check_and_exclude_from_iast_scan_for_api
+          return if check_and_exclude_from_iast_scan_for_detection_category(case_type)
           args.map! { |file| Pathname.new(file).relative? ? File.join(Dir.pwd, file) : file } if [FILE_OPERATION, FILE_INTEGRITY].include?(case_type)
 
           event = NewRelic::Security::Agent::Control::Event.new(case_type, args, event_category)
@@ -44,7 +46,7 @@ module NewRelic::Security
           # Hence, considering only frame absolute_path & lineno for apiId calculation.
           user_frame_index = get_user_frame_index(stk)
           event.apiId = "#{case_type}-#{calculate_api_id(stk[0..user_frame_index].map { |frame| "#{frame.absolute_path}:#{frame.lineno}" }, event.httpRequest[:method], route)}"
-          stk.delete_if {|frame| frame.path.match(/newrelic_security/) || frame.path.match(/new_relic/)}
+          stk.delete_if { |frame| frame.path.match?(/newrelic_security/) || frame.path.match?(/new_relic/) }
           user_frame_index = get_user_frame_index(stk)
           return if case_type != REFLECTED_XSS && user_frame_index == -1 # TODO: Add log message here: "Filtered because User Stk frame NOT FOUND   \r\n"
           if user_frame_index != -1
@@ -59,8 +61,8 @@ module NewRelic::Security
           end
           event.stacktrace = stk[0..user_frame_index].map(&:to_s)
           NewRelic::Security::Agent.agent.event_processor.send_event(event)
-          if event.httpRequest[:headers].key?(NR_CSEC_FUZZ_REQUEST_ID) && event.apiId == event.httpRequest[:headers][NR_CSEC_FUZZ_REQUEST_ID].split(COLON_IAST_COLON)[0]
-            NewRelic::Security::Agent.agent.iast_client.completed_requests[event.parentId] << event.id if NewRelic::Security::Agent.agent.iast_client.completed_requests[event.parentId]
+          if event.httpRequest[:headers].key?(NR_CSEC_FUZZ_REQUEST_ID) && event.apiId == event.httpRequest[:headers][NR_CSEC_FUZZ_REQUEST_ID].split(COLON_IAST_COLON)[0] && NewRelic::Security::Agent.agent.iast_client.completed_requests[event.parentId]
+            NewRelic::Security::Agent.agent.iast_client.completed_requests[event.parentId] << event.id
           end
           event
         rescue Exception => exception
@@ -111,6 +113,35 @@ module NewRelic::Security
           }
         end
 
+        def check_and_exclude_from_iast_scan_for_api
+          NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.api'].each do |api|
+            return true if api&.match?(NewRelic::Security::Agent::Control::HTTPContext.get_context.url)
+          end
+          return false
+        end
+
+        def check_and_exclude_from_iast_scan_for_detection_category(case_type)
+          case case_type
+          when FILE_OPERATION, FILE_INTEGRITY
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access']
+          when SQL_DB_COMMAND
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.sql_injection']
+          when NOSQL_DB_COMMAND
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.nosql_injection']
+          when LDAP
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.ldap_injection']
+          when SYSTEM_COMMAND
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.command_injection']
+          when XPATH
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.xpath_injection']
+          when HTTP_REQUEST
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.ssrf']
+          when REFLECTED_XSS
+            NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.rxss']
+          else
+            false
+          end
+        end
       end
     end
   end

--- a/lib/newrelic_security/agent/control/control_command.rb
+++ b/lib/newrelic_security/agent/control/control_command.rb
@@ -49,8 +49,6 @@ module NewRelic::Security
               message_object[:arguments].each { |processed_id| NewRelic::Security::Agent.agent.iast_client.completed_requests.delete(processed_id) }
             when 100
               NewRelic::Security::Agent.logger.debug "Control command : '100', #{message_object.to_json}"
-              ::NewRelic::Agent.instance.events.notify(:security_policy_received, message_object[:data])
-              # TODO: Update policy from file here, if enabled.
             when 101
 
             when 102

--- a/lib/newrelic_security/agent/control/event.rb
+++ b/lib/newrelic_security/agent/control/event.rb
@@ -30,7 +30,20 @@ module NewRelic::Security
           @appEntityGuid = NewRelic::Security::Agent.config[:entity_guid]
           @httpRequest = Hash.new
           @httpResponse = Hash.new
-          @metaData = { :reflectedMetaData => { :listen_port => NewRelic::Security::Agent.config[:listen_port].to_s }, :appServerInfo => { :applicationDirectory => NewRelic::Security::Agent.config[:app_root], :serverBaseDirectory => NewRelic::Security::Agent.config[:app_root] } }
+          @metaData = {
+            :reflectedMetaData => {
+              :listen_port => NewRelic::Security::Agent.config[:listen_port].to_s
+            },
+            :appServerInfo => { 
+              :applicationDirectory => NewRelic::Security::Agent.config[:app_root], 
+              :serverBaseDirectory => NewRelic::Security::Agent.config[:app_root] 
+            },
+            :skipScanParameters => {
+              :header => NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.http_request_parameters.header'],
+              :query => NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.http_request_parameters.query'],
+              :body => NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.http_request_parameters.body']
+            }
+          }
           @linkingMetadata = add_linking_metadata
           @pid = pid
           @parameters = args

--- a/lib/newrelic_security/agent/control/event_processor.rb
+++ b/lib/newrelic_security/agent/control/event_processor.rb
@@ -48,6 +48,7 @@ module NewRelic::Security
           enqueue(event)
           if @first_event
             NewRelic::Security::Agent.init_logger.info "[STEP-8] => First event sent for validation. Security agent started successfully : #{event.to_json}"
+            NewRelic::Security::Agent.config.traffic_start_time = current_time_millis unless NewRelic::Security::Agent.config[:traffic_start_time]
             @first_event = false
           end
           event = nil
@@ -128,6 +129,10 @@ module NewRelic::Security
           }
         rescue Exception => exception
           NewRelic::Security::Agent.logger.error "Exception in health check thread, #{exception.inspect}"
+        end
+
+        def current_time_millis
+          (Time.now.to_f * 1000).to_i
         end
 
         def create_error_reporting_thread

--- a/lib/newrelic_security/agent/control/event_subscriber.rb
+++ b/lib/newrelic_security/agent/control/event_subscriber.rb
@@ -7,18 +7,12 @@ module NewRelic::Security
               NewRelic::Security::Agent.logger.info "NewRelic server_source_configuration_added for pid : #{Process.pid}, Parent Pid : #{Process.ppid}"
               NewRelic::Security::Agent.init_logger.info "NewRelic server_source_configuration_added for pid : #{Process.pid}, Parent Pid : #{Process.ppid}"
               NewRelic::Security::Agent.config.update_server_config
-              if NewRelic::Security::Agent.config[:enabled] && !NewRelic::Security::Agent.config[:high_security]
-                NewRelic::Security::Agent.agent.init
+              if NewRelic::Security::Agent.config[:'security.enabled'] && !NewRelic::Security::Agent.config[:high_security]
+                Thread.new { NewRelic::Security::Agent.agent.scan_scheduler.init_via_scan_scheduler }
               else
                 NewRelic::Security::Agent.logger.info "New Relic Security is disabled by one of the user provided config `security.enabled` or `high_security`."
                 NewRelic::Security::Agent.init_logger.info "New Relic Security is disabled by one of the user provided config `security.enabled` or `high_security`."
               end
-            }
-            ::NewRelic::Agent.instance.events.subscribe(:security_policy_received) { |received_policy| 
-              NewRelic::Security::Agent.logger.info "security_policy_received pid ::::::: #{Process.pid} #{Process.ppid}, #{received_policy}"
-              NewRelic::Security::Agent.config[:policy].merge!(received_policy)
-              NewRelic::Security::Agent.init_logger.info "[STEP-7] => Received and applied policy/configuration : #{received_policy}"
-              NewRelic::Security::Agent.agent.start_iast_client if NewRelic::Security::Agent::Utils.is_IAST?
             }
         end
       end

--- a/lib/newrelic_security/agent/control/health_check.rb
+++ b/lib/newrelic_security/agent/control/health_check.rb
@@ -35,6 +35,9 @@ module NewRelic::Security
           @iastEventStats = {}
           @raspEventStats = {}
           @exitEventStats = {}
+          @procStartTime = NewRelic::Security::Agent.config[:process_start_time]
+          @trafficStartedTime = NewRelic::Security::Agent.config[:traffic_start_time]
+          @scanStartTime = NewRelic::Security::Agent.config[:scan_start_time]
         end
 
         def as_json

--- a/lib/newrelic_security/agent/control/http_context.rb
+++ b/lib/newrelic_security/agent/control/http_context.rb
@@ -14,6 +14,7 @@ module NewRelic::Security
       PATH_INFO = 'PATH_INFO'
       RACK_INPUT = 'rack.input'
       CGI_VARIABLES = ::Set.new(%W[ AUTH_TYPE CONTENT_LENGTH CONTENT_TYPE GATEWAY_INTERFACE HTTPS HTTP_HOST PATH_INFO PATH_TRANSLATED REQUEST_URI QUERY_STRING REMOTE_ADDR REMOTE_HOST REMOTE_IDENT REMOTE_USER REQUEST_METHOD SCRIPT_NAME SERVER_NAME SERVER_PORT SERVER_PROTOCOL SERVER_SOFTWARE rack.url_scheme ])
+      REQUEST_BODY_LIMIT = 500 #KB
 
       class HTTPContext
         
@@ -31,18 +32,18 @@ module NewRelic::Security
           strio = env[RACK_INPUT]
           if strio.instance_of?(::StringIO)
 						offset = strio.tell
-						@body = strio.read(NewRelic::Security::Agent.config[:'security.request.body_limit'] * 1024) #after read, offset changes
+						@body = strio.read(REQUEST_BODY_LIMIT * 1024) #after read, offset changes
 						strio.seek(offset)
             # In case of Grape and Roda strio.read giving empty result, added below approach to handle such cases
             @body = strio.string if @body.nil? && strio.size > 0
           elsif defined?(::Rack) && defined?(::Rack::Lint::InputWrapper) && strio.instance_of?(::Rack::Lint::InputWrapper)
-						@body = strio.read(NewRelic::Security::Agent.config[:'security.request.body_limit'] * 1024)
+						@body = strio.read(REQUEST_BODY_LIMIT * 1024)
           elsif defined?(::Protocol::Rack::Input) && defined?(::Protocol::Rack::Input) && strio.instance_of?(::Protocol::Rack::Input)
-            @body = strio.read(NewRelic::Security::Agent.config[:'security.request.body_limit'] * 1024)
+            @body = strio.read(REQUEST_BODY_LIMIT * 1024)
           elsif defined?(::PhusionPassenger::Utils::TeeInput) && strio.instance_of?(::PhusionPassenger::Utils::TeeInput)
-						@body = strio.read(NewRelic::Security::Agent.config[:'security.request.body_limit'] * 1024)
+						@body = strio.read(REQUEST_BODY_LIMIT * 1024)
           end
-          @data_truncated = @body && @body.size >= NewRelic::Security::Agent.config[:'security.request.body_limit'] * 1024
+          @data_truncated = @body && @body.size >= REQUEST_BODY_LIMIT * 1024
 					strio&.rewind
 					@body = @body.force_encoding(Encoding::UTF_8) if @body.is_a?(String)
           @cache = Hash.new

--- a/lib/newrelic_security/agent/control/http_context.rb
+++ b/lib/newrelic_security/agent/control/http_context.rb
@@ -12,18 +12,20 @@ module NewRelic::Security
       REQUEST_METHOD = 'REQUEST_METHOD'
       HTTP_HOST = 'HTTP_HOST'
       PATH_INFO = 'PATH_INFO'
+      QUERY_STRING = 'QUERY_STRING'
       RACK_INPUT = 'rack.input'
       CGI_VARIABLES = ::Set.new(%W[ AUTH_TYPE CONTENT_LENGTH CONTENT_TYPE GATEWAY_INTERFACE HTTPS HTTP_HOST PATH_INFO PATH_TRANSLATED REQUEST_URI QUERY_STRING REMOTE_ADDR REMOTE_HOST REMOTE_IDENT REMOTE_USER REQUEST_METHOD SCRIPT_NAME SERVER_NAME SERVER_PORT SERVER_PROTOCOL SERVER_SOFTWARE rack.url_scheme ])
       REQUEST_BODY_LIMIT = 500 #KB
 
       class HTTPContext
         
-        attr_accessor :time_stamp, :req, :method, :headers, :params, :body, :data_truncated, :route, :cache, :fuzz_files, :event_counter, :mutex
+        attr_accessor :time_stamp, :req, :method, :headers, :params, :body, :data_truncated, :route, :cache, :fuzz_files, :event_counter, :mutex, :url
 
         def initialize(env)
           @time_stamp = current_time_millis
           @req = env.select { |key, _| CGI_VARIABLES.include? key}
           @method = @req[REQUEST_METHOD]
+          @url = "#{@req[PATH_INFO]}?#{@req[QUERY_STRING]}"
           @headers = env.select { |key, _| key.include?(HTTP_) }
           @headers = @headers.transform_keys{ |key| key[5..-1].gsub(UNDERSCORE, HYPHEN).downcase }
           request = Rack::Request.new(env) unless env.empty?

--- a/lib/newrelic_security/agent/control/iast_client.rb
+++ b/lib/newrelic_security/agent/control/iast_client.rb
@@ -17,9 +17,8 @@ module NewRelic::Security
       IS_GRPC = 'isGrpc'
       INPUT_CLASS = 'inputClass'
       SERVER_PORT_1 = 'serverPort'
-      PROBING = 'probing'
-      INTERVAL = 'interval'
       IS_GRPC_CLIENT_STREAM = 'isGrpcClientStream'
+      PROBING_INTERVAL = 5
 
       class IASTClient
         
@@ -71,7 +70,8 @@ module NewRelic::Security
           @iast_data_transfer_request_processor_thread = Thread.new do
             Thread.current.name = "newrelic_security_iast_data_transfer_request_processor"
             loop do
-              sleep NewRelic::Security::Agent.config[:policy][VULNERABILITY_SCAN][IAST_SCAN][PROBING][INTERVAL]
+              # TODO: Check & remove this probing interval if not required, earlier this was used from policy sent by SE.
+              sleep PROBING_INTERVAL
               current_timestamp = current_time_millis
               cooldown_sleep_time = @cooldown_till_timestamp - current_timestamp
               sleep cooldown_sleep_time/1000 if cooldown_sleep_time > 0
@@ -98,7 +98,7 @@ module NewRelic::Security
                 end
                 iast_data_transfer_request.pendingRequestIds = pending_request_ids.to_a
                 iast_data_transfer_request.completedRequests = completed_requests
-                NewRelic::Security::Agent.agent.event_processor.send_iast_data_transfer_request(iast_data_transfer_request)
+                NewRelic::Security::Agent.agent.event_processor&.send_iast_data_transfer_request(iast_data_transfer_request)
               end
             end
           end

--- a/lib/newrelic_security/agent/control/iast_client.rb
+++ b/lib/newrelic_security/agent/control/iast_client.rb
@@ -53,6 +53,7 @@ module NewRelic::Security
               Thread.current.name = "newrelic_security_iast_thread-#{t}"
               loop do
                 fuzz_request = @fuzzQ.deq #thread blocks when the queue is empty
+                NewRelic::Security::Agent.config.scan_start_time = current_time_millis unless NewRelic::Security::Agent.config[:scan_start_time]
                 if fuzz_request.request[IS_GRPC]
                   fire_grpc_request(fuzz_request.id, fuzz_request.request, fuzz_request.reflected_metadata)
                 else

--- a/lib/newrelic_security/agent/control/scan_scheduler.rb
+++ b/lib/newrelic_security/agent/control/scan_scheduler.rb
@@ -1,0 +1,77 @@
+require 'newrelic_security/parse-cron/cron_parser'
+
+module NewRelic::Security
+  module Agent
+    module Control
+      class ScanScheduler
+        def init_via_scan_scheduler
+          if NewRelic::Security::Agent.config[:'security.scan_schedule.delay'].positive?
+            NewRelic::Security::Agent.logger.info "IAST delay is set to: #{NewRelic::Security::Agent.config[:'security.scan_schedule.delay']}, current time: #{Time.now}"
+            start_agent_with_delay(NewRelic::Security::Agent.config[:'security.scan_schedule.delay']*60)
+          elsif !NewRelic::Security::Agent.config[:'security.scan_schedule.schedule'].to_s.empty?
+            cron_expression_task(NewRelic::Security::Agent.config[:'security.scan_schedule.schedule'], NewRelic::Security::Agent.config[:'security.scan_schedule.duration']*60)
+          else
+            NewRelic::Security::Agent.agent.init
+            NewRelic::Security::Agent.agent.start_iast_client if NewRelic::Security::Agent::Utils.is_IAST?
+            shutdown_at_duration_reached(NewRelic::Security::Agent.config[:'security.scan_schedule.duration']*60)
+          end
+        rescue StandardError => exception
+          NewRelic::Security::Agent.logger.error "Exception in IAST scan scheduler: #{exception.inspect} #{exception.backtrace}"
+          ::NewRelic::Agent.notice_error(exception)
+        end
+
+        def start_agent_with_delay(delay)
+          NewRelic::Security::Agent.logger.info "Security Agent delay scan time is set to: #{(delay/60).ceil} minutes when always_sample_traces is #{NewRelic::Security::Agent.config[:'security.scan_schedule.always_sample_traces']}, current time: #{Time.now}"
+          if NewRelic::Security::Agent.config[:'security.scan_schedule.always_sample_traces']
+            NewRelic::Security::Agent.agent.init unless NewRelic::Security::Agent.config[:enabled]
+            sleep delay if NewRelic::Security::Agent.config[:'security.scan_schedule.always_sample_traces']
+          else
+            sleep delay
+            NewRelic::Security::Agent.agent.init
+          end
+          NewRelic::Security::Agent.agent.start_iast_client if NewRelic::Security::Agent::Utils.is_IAST?
+          shutdown_at_duration_reached(NewRelic::Security::Agent.config[:'security.scan_schedule.duration']*60)
+        end
+
+        def shutdown_at_duration_reached(duration)
+          shutdown_at = Time.now.to_i + duration
+          shut_down_time = (Time.now + duration).strftime("%a %d %b %Y %H:%M:%S")
+          return if duration <= 0
+          NewRelic::Security::Agent.logger.info "IAST Duration is set to: #{duration/60} minutes, timestamp: #{shut_down_time} time, current time: #{Time.now}"
+          @shutdown_monitor_thread = Thread.new do
+            Thread.current.name = "newrelic_security_shutdown_monitor_thread"
+            loop do
+              sleep 1
+              next if Time.now.to_i < shutdown_at
+              if NewRelic::Security::Agent.config[:'security.scan_schedule.always_sample_traces']
+                NewRelic::Security::Agent.logger.info "Shutdown IAST Data transfer request processor only as 'security.scan_schedule.always_sample_traces' is #{NewRelic::Security::Agent.config[:'security.scan_schedule.always_sample_traces']} now at current time: #{Time.now}"
+                NewRelic::Security::Agent.agent.iast_client&.iast_data_transfer_request_processor_thread&.kill
+              else
+                NewRelic::Security::Agent.logger.info "Shutdown IAST agent now at current time: #{Time.now}"
+                ::NewRelic::Agent.notice_error(StandardError.new("WS Connection closed by local"))
+                NewRelic::Security::Agent.agent.shutdown_security_agent
+              end
+              break
+            end
+          end
+        end
+
+        def cron_expression_task(schedule, duration)
+          @cron_parser = NewRelic::Security::ParseCron::CronParser.new(schedule)
+          loop do
+            next_run = @cron_parser.next(Time.now)
+            NewRelic::Security::Agent.logger.info "Next init via cron exp: #{schedule},  is scheduled at : #{next_run}"
+            delay = next_run - Time.now
+            if NewRelic::Security::Agent.agent.iast_client&.iast_data_transfer_request_processor_thread&.alive?
+              sleep delay > 2 ? delay - 2 : delay
+            else
+              start_agent_with_delay(delay) 
+            end
+            return if duration <= 0
+          end
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/newrelic_security/agent/control/websocket_client.rb
+++ b/lib/newrelic_security/agent/control/websocket_client.rb
@@ -21,6 +21,7 @@ module NewRelic::Security
       NR_CSEC_ENTITY_NAME = 'NR-CSEC-ENTITY-NAME'
       NR_CSEC_ENTITY_GUID = 'NR-CSEC-ENTITY-GUID'
       NR_CSEC_IAST_DATA_TRANSFER_MODE = 'NR-CSEC-IAST-DATA-TRANSFER-MODE'
+      NR_CSEC_IGNORED_VUL_CATEGORIES = 'NR-CSEC-IGNORED-VUL-CATEGORIES'
 
       class WebsocketClient
         include Singleton
@@ -43,6 +44,7 @@ module NewRelic::Security
           headers[NR_CSEC_ENTITY_NAME] = NewRelic::Security::Agent.config[:app_name]
           headers[NR_CSEC_ENTITY_GUID] = NewRelic::Security::Agent.config[:entity_guid]
           headers[NR_CSEC_IAST_DATA_TRANSFER_MODE] = PULL
+          headers[NR_CSEC_IGNORED_VUL_CATEGORIES] = ingnored_vul_categories.join(COMMA)
 
           begin
             cert_store = ::OpenSSL::X509::Store.new
@@ -130,6 +132,20 @@ module NewRelic::Security
           false
         end
 
+        private
+
+        def ingnored_vul_categories
+          list = []
+          list << FILE_OPERATION << FILE_INTEGRITY if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access']
+          list << SQL_DB_COMMAND if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.sql_injection']
+          list << NOSQL_DB_COMMAND if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.nosql_injection']
+          list << LDAP if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.ldap_injection']
+          list << SYSTEM_COMMAND if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.command_injection']
+          list << XPATH if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.xpath_injection']
+          list << HTTP_REQUEST if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.ssrf']
+          list << REFLECTED_XSS if NewRelic::Security::Agent.config[:'security.exclude_from_iast_scan.iast_detection_category.rxss']
+          list
+        end
       end
     end
   end

--- a/lib/newrelic_security/agent/control/websocket_client.rb
+++ b/lib/newrelic_security/agent/control/websocket_client.rb
@@ -22,6 +22,7 @@ module NewRelic::Security
       NR_CSEC_ENTITY_GUID = 'NR-CSEC-ENTITY-GUID'
       NR_CSEC_IAST_DATA_TRANSFER_MODE = 'NR-CSEC-IAST-DATA-TRANSFER-MODE'
       NR_CSEC_IGNORED_VUL_CATEGORIES = 'NR-CSEC-IGNORED-VUL-CATEGORIES'
+      NR_CSEC_PROCESS_START_TIME = 'NR-CSEC-PROCESS-START-TIME'
 
       class WebsocketClient
         include Singleton
@@ -45,6 +46,7 @@ module NewRelic::Security
           headers[NR_CSEC_ENTITY_GUID] = NewRelic::Security::Agent.config[:entity_guid]
           headers[NR_CSEC_IAST_DATA_TRANSFER_MODE] = PULL
           headers[NR_CSEC_IGNORED_VUL_CATEGORIES] = ingnored_vul_categories.join(COMMA)
+          headers[NR_CSEC_PROCESS_START_TIME] = NewRelic::Security::Agent.config[:process_start_time]
 
           begin
             cert_store = ::OpenSSL::X509::Store.new

--- a/lib/newrelic_security/agent/utils/agent_utils.rb
+++ b/lib/newrelic_security/agent/utils/agent_utils.rb
@@ -15,8 +15,7 @@ module NewRelic::Security
       ASTERISK = '*'
 
       def is_IAST?
-        return false if NewRelic::Security::Agent.config[:policy].empty?
-        return NewRelic::Security::Agent.config[:policy][VULNERABILITY_SCAN][IAST_SCAN][ENABLED] if NewRelic::Security::Agent.config[:policy][VULNERABILITY_SCAN][ENABLED]
+        return true if NewRelic::Security::Agent.config[:mode] == IAST
         false
       end
 

--- a/lib/newrelic_security/agent/utils/agent_utils.rb
+++ b/lib/newrelic_security/agent/utils/agent_utils.rb
@@ -96,7 +96,8 @@ module NewRelic::Security
 
       def get_app_routes(framework, router = nil)
         enable_object_space_in_jruby
-        if framework == :rails
+        case framework
+        when :rails
           ::Rails.application.routes.routes.each do |route|
             if route.verb.is_a?(::Regexp)
               method = route.verb.inspect.match(/[a-zA-Z]+/)
@@ -107,27 +108,31 @@ module NewRelic::Security
               }
             end
           end
-        elsif framework == :sinatra
+        when :sinatra
           ::Sinatra::Application.routes.each do |method, routes|
             routes.map { |r| r.first.to_s }.map do |route|
               NewRelic::Security::Agent.agent.route_map << "#{method}@#{route}"
             end
           end
-        elsif framework == :grape
+        when :grape
           ObjectSpace.each_object(::Grape::Endpoint) { |z|
             z.instance_variable_get(:@routes)&.each { |route|
               http_method = route.instance_variable_get(:@request_method) || route.instance_variable_get(:@options)[:method]
               NewRelic::Security::Agent.agent.route_map << "#{http_method}@#{route.pattern.origin}"
             }
           }
-        elsif framework == :padrino
+        when :padrino
           if router.instance_of?(::Padrino::PathRouter::Router)
             router.instance_variable_get(:@routes).each do |route|
               NewRelic::Security::Agent.agent.route_map << "#{route.instance_variable_get(:@verb)}@#{route.matcher.instance_variable_get(:@path)}"
             end
           end
-        elsif framework == :roda
+        when :roda
           NewRelic::Security::Agent.logger.warn "TODO: Roda is a routing tree web toolkit, which generates route dynamically, hence route extraction is not possible."
+        when :grpc
+          router.owner.superclass.public_instance_methods(false).each do |m|
+            NewRelic::Security::Agent.agent.route_map << "*@/#{router.owner}/#{m}"
+          end
         else
           NewRelic::Security::Agent.logger.error "Unable to get app routes as Framework not detected"
         end

--- a/lib/newrelic_security/constants.rb
+++ b/lib/newrelic_security/constants.rb
@@ -17,6 +17,7 @@ module NewRelic::Security
   NR_CSEC_FUZZ_REQUEST_ID = 'nr-csec-fuzz-request-id'
   NR_CSEC_TRACING_DATA = 'nr-csec-tracing-data'
   NR_CSEC_PARENT_ID = 'nr-csec-parent-id'
+  IAST = 'IAST'
   COLON_IAST_COLON = ':IAST:'
   NOSQL_DB_COMMAND = 'NOSQL_DB_COMMAND'
   SQL_DB_COMMAND = 'SQL_DB_COMMAND'
@@ -63,6 +64,4 @@ module NewRelic::Security
   CONTENT_TYPE1 = 'content-Type'
   PULL = 'PULL'
   SHA1 = 'sha1'
-  VULNERABILITY_SCAN = 'vulnerabilityScan'
-  IAST_SCAN = 'iastScan'
 end

--- a/lib/newrelic_security/instrumentation-security/async-http/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/async-http/instrumentation.rb
@@ -6,22 +6,11 @@ module NewRelic::Security
   module Instrumentation
     module AsyncHttp
 
-      def call_on_enter(method, url, headers, body)
+      def call_on_enter(_method, url, headers, _body)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = method
         uri = ::URI.parse url
-        ob[:scheme]  = uri.scheme
-        ob[:host]    = uri.host
-        ob[:port]    = uri.port
-        ob[:URI]     = uri.to_s
-        ob[:path]    = uri.path
-        ob[:query]   = uri.query
-        ob[:Body] = body.respond_to?(:join) ? body.join.to_s : body.to_s
-        ob[:Headers] = headers.to_h
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri.to_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.append_tracing_data(headers, event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/curb/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/curb/instrumentation.rb
@@ -12,20 +12,7 @@ module NewRelic::Security
         self.requests.each {
           |key, req|
           uri = NewRelic::Security::Instrumentation::InstrumentationUtils.parse_uri(req.url)
-          ob = {}
-          if uri
-            ob[:Method]  = nil
-            ob[:scheme]  = uri.scheme
-            ob[:host]    = uri.host
-            ob[:port]    = uri.port
-            ob[:URI]     = uri.to_s
-            ob[:path]    = uri.path
-            ob[:query]   = uri.query
-            ob[:Body]    = req.post_body
-            ob[:Headers] = req.headers
-            ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-            ic_args.push(ob)
-          end
+          ic_args.push(uri.to_s) if uri
         }
         event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, ic_args)
         self.requests.each { |key, req| NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(req.headers, event) } if event

--- a/lib/newrelic_security/instrumentation-security/ethon/chain.rb
+++ b/lib/newrelic_security/instrumentation-security/ethon/chain.rb
@@ -7,12 +7,6 @@ module NewRelic::Security
             ::Ethon::Easy.class_eval do
               include NewRelic::Security::Instrumentation::Ethon::Easy
 
-              alias_method :fabricate_without_security, :fabricate
-    
-              def fabricate(url, action_name, options)
-                fabricate_on_enter(url, action_name, options) { return fabricate_without_security(url, action_name, options) }
-              end
-
               alias_method(:headers_equals_without_security, :headers=)
     
               def headers=(headers)

--- a/lib/newrelic_security/instrumentation-security/ethon/prepend.rb
+++ b/lib/newrelic_security/instrumentation-security/ethon/prepend.rb
@@ -4,10 +4,6 @@ module NewRelic::Security
       module Easy
         module Prepend
           include NewRelic::Security::Instrumentation::Ethon::Easy
-
-          def fabricate(url, action_name, options)
-            fabricate_on_enter(url, action_name, options) { return super }
-          end
   
           def headers=(headers)
             headers_equals_on_enter(headers) { return super }

--- a/lib/newrelic_security/instrumentation-security/excon/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/excon/instrumentation.rb
@@ -5,21 +5,11 @@ module NewRelic::Security
   module Instrumentation
     module Excon::Connection
 
-      def request_on_enter(params)
+      def request_on_enter(_params)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = params[:method]
-        ob[:scheme]  = self.data[:scheme]
-        ob[:host]    = self.data[:host]
-        ob[:port]    = self.data[:port]
-        ob[:URI]     = self.data[:query].nil? ? "#{self.data[:host]}#{self.data[:path]}" : "#{self.data[:host]}#{self.data[:path]}?#{self.data[:query]}"
-        ob[:path]    = self.data[:path]
-        ob[:query]   = self.data[:query]
-        ob[:Body] = self.data[:body]
-        ob[:Headers] = self.data[:headers]
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        uri = "#{self.data[:scheme]}://#{self.data[:host]}#{self.data[:path]}"
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(self.data[:headers], event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/grape/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/grape/instrumentation.rb
@@ -8,6 +8,7 @@ module NewRelic::Security
       def call_on_enter(env)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
+        return unless NewRelic::Security::Agent.config[:enabled]
         NewRelic::Security::Agent.config.update_port = NewRelic::Security::Agent::Utils.app_port(env) unless NewRelic::Security::Agent.config[:listen_port]
         NewRelic::Security::Agent::Utils.get_app_routes(:grape) if NewRelic::Security::Agent.agent.route_map.empty?
         NewRelic::Security::Agent::Control::HTTPContext.set_context(env)

--- a/lib/newrelic_security/instrumentation-security/grpc/server/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/grpc/server/instrumentation.rb
@@ -6,7 +6,7 @@ module NewRelic::Security
   module Instrumentation
     module GRPC
       module RpcDesc
-        def grpc_server_on_enter(active_call, mth, inter_ctx, is_grpc_client_stream, is_grpc_server_stream)
+        def grpc_server_on_enter(active_call, mth, _inter_ctx, is_grpc_client_stream, is_grpc_server_stream)
           event = nil
           NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
           grpc_request = {}
@@ -14,10 +14,11 @@ module NewRelic::Security
           grpc_request[:peer] = active_call.peer
           # puts "mth : #{mth.class} #{mth.methods}"
           # puts "mth :#{mth.original_name}, #{mth.to_s}, #{mth.name}, #{mth.receiver}, #{mth.parameters}, #{mth.owner}, #{mth.unbind}, #{mth.super_method},, #{mth.instance_variables}"
+          NewRelic::Security::Agent::Utils.get_app_routes(:grpc, mth) if NewRelic::Security::Agent.agent.route_map.empty?
           grpc_request[:method] = "#{mth.owner}/#{mth.original_name}"
           grpc_request[:is_grpc_client_stream] = is_grpc_client_stream
           grpc_request[:is_grpc_server_stream] = is_grpc_server_stream
-          is_grpc_client_stream ? grpc_request[:body] = [] : grpc_request[:body] = ::String.new
+          grpc_request[:body] = is_grpc_client_stream ? [] : ::String.new
           NewRelic::Security::Agent::Control::GRPCContext.set_context(grpc_request)
           NewRelic::Security::Agent::Utils.parse_fuzz_header(NewRelic::Security::Agent::Control::GRPCContext.get_context)
         rescue => exception

--- a/lib/newrelic_security/instrumentation-security/httpclient/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/httpclient/instrumentation.rb
@@ -8,20 +8,8 @@ module NewRelic::Security
       def do_request_on_enter(method, uri, query, body, header)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = method
-        unless uri.nil?
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-        end
-        ob[:Body] = body
-        ob[:Headers] = header
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        uri_s = uri.to_s unless uri.nil?
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(header, event) if event
         event
       rescue => exception
@@ -43,20 +31,8 @@ module NewRelic::Security
       def do_request_async_on_enter(method, uri, query, body, header)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = method
-        unless uri.nil?
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-        end
-        ob[:Body] = body
-        ob[:Headers] = header
-        ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        uri_s = uri.to_s unless uri.nil?
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(header, event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/httprb/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/httprb/instrumentation.rb
@@ -8,19 +8,8 @@ module NewRelic::Security
       def perform_on_enter(request, options)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-				ob[:Method] = request.verb
-        ob[:scheme] = request.scheme
-        ob[:host] = request.uri.host
-        ob[:port] = request.uri.port
-        ob[:URI] = request.uri.to_s
-        ob[:path] = request.uri.path
-        ob[:query] = request.uri.query
-        ob[:Body] = request.body.source.to_s
-        ob[:Headers] = options.headers.to_h
-        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [request.uri.to_s])
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(options.headers, event) if event
-        ob = nil
         event
       rescue => exception
         NewRelic::Security::Agent.logger.error "Exception in hook in #{self.class}.#{__method__}, #{exception.inspect}, #{exception.backtrace}"

--- a/lib/newrelic_security/instrumentation-security/httpx/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/httpx/instrumentation.rb
@@ -9,21 +9,7 @@ module NewRelic::Security
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
         ic_args = []
-        args.each do |arg|
-          ob = {}
-          ob[:Method] = arg.verb
-          uri = arg.uri
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-          ob[:Body]    = arg.body.bytesize.positive? ? arg.body.to_s : ""
-          ob[:Headers] = arg.headers
-          ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-          ic_args << ob
-        end
+        args.each { |arg| ic_args << arg.uri.to_s }
         event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, ic_args)
         args.each do |arg|
           NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(arg.headers, event) if event

--- a/lib/newrelic_security/instrumentation-security/instrumentation_utils.rb
+++ b/lib/newrelic_security/instrumentation-security/instrumentation_utils.rb
@@ -143,23 +143,6 @@ module NewRelic::Security
         return nil
       end
 
-      def parse_typhoeus_request(request)
-        ob = {}
-        ob[:Method] = request.options[:method].nil? ? :get : request.options[:method]
-        ob[:URI] = request.base_url
-        ob[:Body] = request.options[:body]
-        ob[:Headers] = request.options[:headers]
-        uri_parsed = parse_uri(request.base_url)
-        if !uri_parsed.nil?
-          ob[:scheme] = uri_parsed.scheme
-          ob[:host] = uri_parsed.host
-          ob[:port] = uri_parsed.port
-          ob[:path] = uri_parsed.path
-          ob[:query] = uri_parsed.query
-        end
-        ob
-      end
-
     end
   end
 end

--- a/lib/newrelic_security/instrumentation-security/net_ldap/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/net_ldap/instrumentation.rb
@@ -18,7 +18,7 @@ module NewRelic::Security
           # to know the capabilities of Ldap server. In these
           # situations they don't provide the query parameter, so we filter
           # this event
-          NewRelic::Security::Agent.logger.info "Filtered #{self.class}.#{__method__} because of insufficient args. args : #{args}\n"
+          NewRelic::Security::Agent.logger.debug "Filtered #{self.class}.#{__method__} because of insufficient args. args : #{args}\n"
         end
       rescue => exception
         NewRelic::Security::Agent.logger.error "Exception in hook in #{self.class}.#{__method__}, #{exception.inspect}, #{exception.backtrace}"

--- a/lib/newrelic_security/instrumentation-security/padrino/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/padrino/instrumentation.rb
@@ -8,6 +8,7 @@ module NewRelic::Security
       def call_on_enter(env)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
+        return unless NewRelic::Security::Agent.config[:enabled]
         NewRelic::Security::Agent.config.update_port = NewRelic::Security::Agent::Utils.app_port(env) unless NewRelic::Security::Agent.config[:listen_port]
         NewRelic::Security::Agent::Utils.get_app_routes(:padrino, self) if NewRelic::Security::Agent.agent.route_map.empty?
         extracted_env = env.instance_variable_get(:@env)

--- a/lib/newrelic_security/instrumentation-security/patron/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/patron/instrumentation.rb
@@ -7,25 +7,12 @@ module NewRelic::Security
   module Instrumentation
     module Patron::Session
 
-      def request_on_enter(action, url, headers, options)
+      def request_on_enter(_action, url, headers, _options)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
-        ob = {}
-        ob[:Method] = action
         final_url = self.base_url.nil? ? url : "#{self.base_url}#{url}"
         uri = NewRelic::Security::Instrumentation::InstrumentationUtils.parse_uri(final_url)
-        if uri
-          ob[:scheme]  = uri.scheme
-          ob[:host]    = uri.host
-          ob[:port]    = uri.port
-          ob[:URI]     = uri.to_s
-          ob[:path]    = uri.path
-          ob[:query]   = uri.query
-          ob[:Body] = options[:data]
-          ob[:Headers] = headers
-          ob.each { |_, value| value.dup.force_encoding(ISO_8859_1).encode(UTF_8) if value.is_a?(String) }
-          event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [ob])
-        end
+        event = NewRelic::Security::Agent::Control::Collector.collect(HTTP_REQUEST, [uri.to_s]) if uri
         NewRelic::Security::Instrumentation::InstrumentationUtils.add_tracing_data(headers, event) if event
         event
       rescue => exception

--- a/lib/newrelic_security/instrumentation-security/rails/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/rails/instrumentation.rb
@@ -8,6 +8,7 @@ module NewRelic::Security
       def call_on_enter(env)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
+        return unless NewRelic::Security::Agent.config[:enabled]
         NewRelic::Security::Agent.config.update_port = NewRelic::Security::Agent::Utils.app_port(env) unless NewRelic::Security::Agent.config[:listen_port]
         NewRelic::Security::Agent::Utils.get_app_routes(:rails) if NewRelic::Security::Agent.agent.route_map.empty?
         NewRelic::Security::Agent::Control::HTTPContext.set_context(env)

--- a/lib/newrelic_security/instrumentation-security/roda/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/roda/instrumentation.rb
@@ -8,6 +8,7 @@ module NewRelic::Security
       def _roda_handle_main_route_on_enter(env)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
+        return unless NewRelic::Security::Agent.config[:enabled]
         NewRelic::Security::Agent.config.update_port = NewRelic::Security::Agent::Utils.app_port(env) unless NewRelic::Security::Agent.config[:listen_port]
         NewRelic::Security::Agent::Utils.get_app_routes(:roda) if NewRelic::Security::Agent.agent.route_map.empty?
         NewRelic::Security::Agent::Control::HTTPContext.set_context(env)

--- a/lib/newrelic_security/instrumentation-security/sinatra/instrumentation.rb
+++ b/lib/newrelic_security/instrumentation-security/sinatra/instrumentation.rb
@@ -8,6 +8,7 @@ module NewRelic::Security
       def call_on_enter(env)
         event = nil
         NewRelic::Security::Agent.logger.debug "OnEnter : #{self.class}.#{__method__}"
+        return unless NewRelic::Security::Agent.config[:enabled]
         NewRelic::Security::Agent.config.update_port = NewRelic::Security::Agent::Utils.app_port(env) unless NewRelic::Security::Agent.config[:listen_port]
         NewRelic::Security::Agent::Utils.get_app_routes(:sinatra) if NewRelic::Security::Agent.agent.route_map.empty?
         NewRelic::Security::Agent::Control::HTTPContext.set_context(env)

--- a/lib/newrelic_security/newrelic-security-api/api.rb
+++ b/lib/newrelic_security/newrelic-security-api/api.rb
@@ -14,7 +14,7 @@ module NewRelic::Security
     # @api public
     # 
     def is_security_active?
-      NewRelic::Security::Agent.config[:'agent.enabled'] && NewRelic::Security::Agent.config[:enabled]
+      NewRelic::Security::Agent.config[:'agent.enabled'] && NewRelic::Security::Agent.config[:'security.enabled'] && NewRelic::Security::Agent.config[:enabled]
     end
 
     #

--- a/lib/newrelic_security/parse-cron/cron_parser.rb
+++ b/lib/newrelic_security/parse-cron/cron_parser.rb
@@ -1,0 +1,294 @@
+require 'set'
+require 'date'
+
+module NewRelic::Security
+  module ParseCron
+
+    # Parses cron expressions and computes the next occurence of the "job"
+    class CronParser
+      # internal "mutable" time representation
+      class InternalTime
+        attr_accessor :year, :month, :day, :hour, :min, :time_source
+
+        def initialize(time, time_source = Time)
+          @year = time.year
+          @month = time.month
+          @day = time.day
+          @hour = time.hour
+          @min = time.min
+
+          @time_source = time_source
+        end
+
+        def to_time
+          time_source.local(@year, @month, @day, @hour, @min, 0)
+        end
+
+        def inspect
+          [year, month, day, hour, min].inspect
+        end
+      end
+
+      SYMBOLS = {
+        "jan" => "1",
+        "feb" => "2",
+        "mar" => "3",
+        "apr" => "4",
+        "may" => "5",
+        "jun" => "6",
+        "jul" => "7",
+        "aug" => "8",
+        "sep" => "9",
+        "oct" => "10",
+        "nov" => "11",
+        "dec" => "12",
+
+        "sun" => "0",
+        "mon" => "1",
+        "tue" => "2",
+        "wed" => "3",
+        "thu" => "4",
+        "fri" => "5",
+        "sat" => "6"
+      }
+
+      def initialize(source, time_source = Time)
+        @source = interpret_vixieisms(source)
+        @time_source = time_source
+        validate_source
+      end
+
+      def interpret_vixieisms(spec)
+        case spec
+        when '@reboot'
+          raise ArgumentError, "Can't predict last/next run of @reboot"
+        when '@yearly', '@annually'
+          '0 0 1 1 *'
+        when '@monthly'
+          '0 0 1 * *'
+        when '@weekly'
+          '0 0 * * 0'
+        when '@daily', '@midnight'
+          '0 0 * * *'
+        when '@hourly'
+          '0 * * * *'
+        else
+          spec
+        end
+      end
+
+      # returns the next occurence after the given date
+      def next(now = @time_source.now, num = 1)
+        t = InternalTime.new(now, @time_source)
+
+        unless time_specs[:month][0].include?(t.month)
+          nudge_month(t)
+          t.day = 0
+        end
+
+        unless interpolate_weekdays(t.year, t.month)[0].include?(t.day)
+          nudge_date(t)
+          t.hour = -1
+        end
+
+        unless time_specs[:hour][0].include?(t.hour)
+          nudge_hour(t)
+          t.min = -1
+        end
+
+        # always nudge the minute
+        nudge_minute(t)
+        t = t.to_time
+        if num > 1
+          recursive_calculate(:next, t, num)
+        else
+          t
+        end
+      end
+
+      # returns the last occurence before the given date
+      def last(now = @time_source.now, num = 1)
+        t = InternalTime.new(now, @time_source)
+
+        unless time_specs[:month][0].include?(t.month)
+          nudge_month(t, :last)
+          t.day = 32
+        end
+
+        if t.day == 32 || !interpolate_weekdays(t.year, t.month)[0].include?(t.day)
+          nudge_date(t, :last)
+          t.hour = 24
+        end
+
+        unless time_specs[:hour][0].include?(t.hour)
+          nudge_hour(t, :last)
+          t.min = 60
+        end
+
+        # always nudge the minute
+        nudge_minute(t, :last)
+        t = t.to_time
+        if num > 1
+          recursive_calculate(:last, t, num)
+        else
+          t
+        end
+      end
+
+      SUBELEMENT_REGEX = %r{^(\d+)(-(\d+)(/(\d+))?)?$}
+      def parse_element(elem, allowed_range)
+        values = elem.split(',').map do |subel|
+          if subel =~ /^\*/
+            step = subel.length > 1 ? subel[2..-1].to_i : 1
+            stepped_range(allowed_range, step)
+          else
+            raise ArgumentError, "Bad Vixie-style specification #{subel}" unless SUBELEMENT_REGEX === subel
+            if ::Regexp.last_match(5) # with range
+              stepped_range(::Regexp.last_match(1).to_i..::Regexp.last_match(3).to_i, ::Regexp.last_match(5).to_i)
+            elsif ::Regexp.last_match(3) # range without step
+              stepped_range(::Regexp.last_match(1).to_i..::Regexp.last_match(3).to_i, 1)
+            else # just a numeric
+              [::Regexp.last_match(1).to_i]
+            end
+            
+              
+            
+          end
+        end.flatten.sort
+
+        [Set.new(values), values, elem]
+      end
+
+      protected
+
+      def recursive_calculate(meth, time, num)
+        array = [time]
+        num.-(1).times do |_num|
+          array << send(meth, array.last)
+        end
+        array
+      end
+
+      # returns a list of days which do both match time_spec[:dom] or time_spec[:dow]
+      def interpolate_weekdays(year, month)
+        @_interpolate_weekdays_cache ||= {}
+        @_interpolate_weekdays_cache["#{year}-#{month}"] ||= interpolate_weekdays_without_cache(year, month)
+      end
+
+      def interpolate_weekdays_without_cache(year, month)
+        t = Date.new(year, month, 1)
+        valid_mday, _, mday_field = time_specs[:dom]
+        valid_wday, _, wday_field = time_specs[:dow]
+
+        # Careful, if both DOW and DOM fields are non-wildcard,
+        # then we only need to match *one* for cron to run the job:
+        unless mday_field == '*' and wday_field == '*'
+          valid_mday = [] if mday_field == '*'
+          valid_wday = [] if wday_field == '*'
+        end
+        # Careful: crontabs may use either 0 or 7 for Sunday:
+        valid_wday << 0 if valid_wday.include?(7)
+
+        result = []
+        while t.month == month
+          result << t.mday if valid_mday.include?(t.mday) || valid_wday.include?(t.wday)
+          t = t.succ
+        end
+
+        [Set.new(result), result]
+      end
+
+      def nudge_year(t, dir = :next)
+        t.year = t.year + (dir == :next ? 1 : -1)
+      end
+
+      def nudge_month(t, dir = :next)
+        spec = time_specs[:month][1]
+        next_value = find_best_next(t.month, spec, dir)
+        t.month = next_value || (dir == :next ? spec.first : spec.last)
+
+        nudge_year(t, dir) if next_value.nil?
+
+        # we changed the month, so its likely that the date is incorrect now
+        valid_days = interpolate_weekdays(t.year, t.month)[1]
+        t.day = dir == :next ? valid_days.first : valid_days.last
+      end
+
+      def date_valid?(t, _dir = :next)
+        interpolate_weekdays(t.year, t.month)[0].include?(t.day)
+      end
+
+      def nudge_date(t, dir = :next, can_nudge_month = true)
+        spec = interpolate_weekdays(t.year, t.month)[1]
+        next_value = find_best_next(t.day, spec, dir)
+        t.day = next_value || (dir == :next ? spec.first : spec.last)
+
+        nudge_month(t, dir) if next_value.nil? && can_nudge_month
+      end
+
+      def nudge_hour(t, dir = :next)
+        spec = time_specs[:hour][1]
+        next_value = find_best_next(t.hour, spec, dir)
+        t.hour = next_value || (dir == :next ? spec.first : spec.last)
+
+        nudge_date(t, dir) if next_value.nil?
+      end
+
+      def nudge_minute(t, dir = :next)
+        spec = time_specs[:minute][1]
+        next_value = find_best_next(t.min, spec, dir)
+        t.min = next_value || (dir == :next ? spec.first : spec.last)
+
+        nudge_hour(t, dir) if next_value.nil?
+      end
+
+      def time_specs
+        @time_specs ||= begin
+          # tokens now contains the 5 fields
+          tokens = substitute_parse_symbols(@source).split(/\s+/)
+          {
+            :minute => parse_element(tokens[0], 0..59), #minute
+            :hour => parse_element(tokens[1], 0..23), #hour
+            :dom => parse_element(tokens[2], 1..31), #DOM
+            :month => parse_element(tokens[3], 1..12), #mon
+            :dow => parse_element(tokens[4], 0..6) #DOW
+          }
+        end
+      end
+
+      def substitute_parse_symbols(str)
+        SYMBOLS.inject(str.downcase) do |s, (symbol, replacement)|
+          s.gsub(symbol, replacement)
+        end
+      end
+
+      def stepped_range(rng, step = 1)
+        len = rng.last - rng.first
+
+        num = len.div(step)
+        result = (0..num).map { |i| rng.first + (step * i) }
+
+        result.pop if result[-1] == rng.last and rng.exclude_end?
+        result
+      end
+
+      # returns the smallest element from allowed which is greater than current
+      # returns nil if no matching value was found
+      def find_best_next(current, allowed, dir)
+        if dir == :next
+          allowed.sort.find { |val| val > current }
+        else
+          allowed.sort.reverse.find { |val| val < current }
+        end
+      end
+
+      def validate_source
+        raise ArgumentError, 'not a valid cronline' unless @source.respond_to?(:split)
+        source_length = @source.split(/\s+/).length
+        return if source_length >= 5 && source_length <= 6
+        raise ArgumentError, 'not a valid cronline'
+        
+      end
+    end
+  end
+end

--- a/lib/newrelic_security/version.rb
+++ b/lib/newrelic_security/version.rb
@@ -1,5 +1,5 @@
 module NewRelic
   module Security
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/newrelic_security.gemspec
+++ b/newrelic_security.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   ]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'newrelic_rpm', '>= 9.12.0'
+  spec.add_dependency 'newrelic_rpm', '>= 9.16.0'
 
   spec.add_development_dependency 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '~> 5.18' : '4.7.5'}"
 

--- a/test/helpers/config_helper.rb
+++ b/test/helpers/config_helper.rb
@@ -18,6 +18,7 @@ module NewRelic
             @cache[:policy] = Hash.new
             @cache[:'security.detection.rxss.enabled'] = true
             @cache[:'security.request.body_limit'] = 300
+            @cache[:enabled] = true
           end
         end
       end

--- a/test/newrelic_security/instrumentation-security/async-http/async_http_test.rb
+++ b/test/newrelic_security/instrumentation-security/async-http/async_http_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Security
                 end
 
                 def test_get
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com/search?q=test", :path=>"/search", :query=>"q=test", :Body=>"", :Headers=>{"accept"=>"application/json"}}]
+                    args = ["http://www.google.com/search?q=test"]
                     response = nil
                     Async do
                         begin
@@ -26,23 +26,19 @@ module NewRelic::Security
                         ensure
                             internet.close
                         end
-                        # TODO: Ensure without begin/end supported after RUBY_VERSION >= 2.5, remove rescue to optimize.
+                      # TODO: Ensure without begin/end supported after RUBY_VERSION >= 2.5, remove rescue to optimize.
                     end
                     assert_equal 200, response.status
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 if RUBY_VERSION >= '2.5.0'
                     def test_get_ssl
-                        args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/search?q=test", :path=>"/search", :query=>"q=test", :Body=>"", :Headers=>{"accept"=>"application/json"}}]
+                        args = ["https://www.google.com/search?q=test"]
                         response = nil
                         Async do
                             begin
@@ -59,18 +55,14 @@ module NewRelic::Security
                         expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                         assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                         assert_equal expected_event.caseType, $event_list[0].caseType
-                        assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                        assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                        assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                        assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                        assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                        assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                         assert_nil $event_list[0].eventCategory
                     end
                 end
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>"POST", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books"]
                     data = {"title"=>"New", "author"=>"New Author"}
                     response = nil
                     Async do
@@ -90,18 +82,14 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"PUT", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
-                    data = {"title"=>"Update Book","author"=>"Update Author"}
+                    args = ["http://localhost:9291/books/1"]
+                    data = {"title"=>"Update Book", "author"=>"Update Author"}
                     response = nil
                     Async do
                         begin
@@ -120,17 +108,13 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"DELETE", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = nil
                     Async do
                         begin
@@ -147,11 +131,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 

--- a/test/newrelic_security/instrumentation-security/curb/curb_test.rb
+++ b/test/newrelic_security/instrumentation-security/curb/curb_test.rb
@@ -8,7 +8,7 @@ module NewRelic::Security
         module Instrumentation
             class TestCurb < Minitest::Test
                 TEST_URL = "https://www.google.com"
-                ARGS = [{:Method=>nil, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                ARGS = ["https://www.google.com"]
 
                 def setup
                     $event_list.clear()

--- a/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
+++ b/test/newrelic_security/instrumentation-security/ethon/ethon_test.rb
@@ -14,7 +14,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil}]
+                    args = ["http://www.google.com"]
                     easy = Ethon::Easy.new(url: url)
                     response = easy.perform
                     @output = response
@@ -28,7 +28,7 @@ module NewRelic::Security
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = [{:scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil}]
+                    args = ["https://www.google.com"]
                     easy = Ethon::Easy.new(url: url)
                     response = easy.perform
                     @output = response
@@ -42,7 +42,7 @@ module NewRelic::Security
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>:post, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\" : \"New Book\", \"author\": \"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books"]
                     # response = HTTPX.post(url, :json => {:name => "testuser", :salary => "123", :age => "23"})
                     easy = Ethon::Easy.new
                     easy.http_request(url, :post, body: '{"title" : "New Book", "author": "New Author"}')
@@ -58,7 +58,7 @@ module NewRelic::Security
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:put, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\": \"Update Book\", \"author\": \"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
+                    args = ["http://localhost:9291/books/1"]
                     # response = HTTPX.put(url, :json => {:name => "testuser", :salary => "123",:age => "23"})
                     easy = Ethon::Easy.new
                     easy.http_request(url, :put, { body: '{"title": "Update Book", "author": "Update Author"}'})
@@ -74,7 +74,7 @@ module NewRelic::Security
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:delete, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>nil, :Headers=>{"User-Agent"=>"ethon"}}]
+                    args = ["http://localhost:9291/books/1"]
                     # response = HTTPX.delete(url)
                     easy = Ethon::Easy.new
                     easy.http_request(url, :delete)
@@ -102,7 +102,7 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:Method=>:get, :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>nil}, {:Method=>:get, :scheme=>"https", :host=>"newrelic.com", :port=>443, :URI=>"https://newrelic.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"User-Agent"=>"ethon"}}]
+                    args = ["http://www.google.com", "https://newrelic.com"]
 
                     multi = Ethon::Multi.new
                     easy = Ethon::Easy.new

--- a/test/newrelic_security/instrumentation-security/excon/excon_test.rb
+++ b/test/newrelic_security/instrumentation-security/excon/excon_test.rb
@@ -16,17 +16,10 @@ module NewRelic::Security
                     skip("Skipping for ruby 2.4.10 && instrumentation method chain") if RUBY_VERSION == '2.4.10' && ENV['NR_CSEC_INSTRUMENTATION_METHOD'] == 'chain'
                     url = "http://google.com"
                     @output = Excon.get(url).body
-                    args = [{:Method=>:get, :scheme=>"http", :host=>"google.com", :port=>80, :URI=>"google.com", :path=>"", :query=>nil, :Body=>nil}]
+                    args = ["http://google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:host], $event_list[0].parameters[0][:host]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:path], $event_list[0].parameters[0][:path]
-                    assert_nil $event_list[0].parameters[0][:query]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
                 

--- a/test/newrelic_security/instrumentation-security/httpclient/httpclient_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpclient/httpclient_test.rb
@@ -16,7 +16,7 @@ module NewRelic::Security
                     client = HTTPClient.new
 	                @output = client.get_content(url)
                     #puts @output
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -29,7 +29,7 @@ module NewRelic::Security
                     client = HTTPClient.new
                     method = 'GET'
                     assert_equal 200, client.request(method, url).code
-                    args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -41,7 +41,7 @@ module NewRelic::Security
                     url = "https://www.google.com"
                     client = HTTPClient.new
                     assert_equal 200, client.get(url, :follow_redirect => true).code
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -53,7 +53,7 @@ module NewRelic::Security
                     url = "https://www.google.com"
                     client = HTTPClient.new
                     assert_equal 200, client.head(url).code
-                    args = [{:Method=>:head, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -72,7 +72,7 @@ module NewRelic::Security
                     @output = str
                     #puts @output
                     #assert_equal 200, @output 
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
+++ b/test/newrelic_security/instrumentation-security/httprb/httprb_test.rb
@@ -13,8 +13,8 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:Method=>:get, :scheme=>:http, :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com/?foo=bar", :path=>"/", :query=>"foo=bar", :Body=>"", :Headers=>{"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}}]
-                    response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
+                    args = ["http://www.google.com/?foo=bar"]
+                    response = HTTP.headers({"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -25,8 +25,8 @@ module NewRelic::Security
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = [{:Method=>:get, :scheme=>:https, :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/?foo=bar", :path=>"/", :query=>"foo=bar", :Body=>"", :Headers=>{"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}}]
-                    response = HTTP.headers(args[0][:Headers]).get(url, :params => {:foo => "bar"})
+                    args = ["https://www.google.com/?foo=bar"]
+                    response = HTTP.headers({"Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "Accept"=>"*/*", "User-Agent"=>"Ruby", "Connection"=>"close"}).get(url, :params => {:foo => "bar"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -37,8 +37,8 @@ module NewRelic::Security
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>:post, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
-                    response = HTTP.headers(args[0][:Headers]).post(url, :json => {:title => "New", :author => "New Author"} )
+                    args = ["http://localhost:9291/books"]
+                    response = HTTP.headers({"Content-Type"=>"application/json"}).post(url, :json => {:title => "New", :author => "New Author"})
                     assert_equal 201, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -49,8 +49,8 @@ module NewRelic::Security
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:put, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{"Content-Type"=>"application/json"}}]
-                    response = HTTP.headers(args[0][:Headers]).put(url, :json => {:title => "Update Book", :author => "Update Author"})
+                    args = ["http://localhost:9291/books/1"]
+                    response = HTTP.headers({"Content-Type"=>"application/json"}).put(url, :json => {:title => "Update Book", :author => "Update Author"})
                     assert_equal 200, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
@@ -61,7 +61,7 @@ module NewRelic::Security
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:delete, :scheme=>:http, :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = HTTP.delete(url)
                     assert_equal 204, response.code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)

--- a/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
+++ b/test/newrelic_security/instrumentation-security/httpx/httpx_test.rb
@@ -13,86 +13,66 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com"
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://www.google.com"]
                     response = HTTPX.get(url)
                     @output = response.status
                     assert_equal 200, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
                     url = "https://www.google.com"
-                    args = [{:Method=>"GET", :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com", :path=>"", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["https://www.google.com"]
                     response = HTTPX.get(url)
                     @output = response.status
                     assert_equal 200, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>"POST", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{}}]
-                    response = HTTPX.post(url, :json => {"title"=>"New","author"=>"New Author"})
+                    args = ["http://localhost:9291/books"]
+                    response = HTTPX.post(url, :json => {"title"=>"New", "author"=>"New Author"})
                     @output = response.status
                     assert_equal 201, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"PUT", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{}}]
-                    response = HTTPX.put(url, :json => {"title"=>"Update Book","author"=>"Update Author"})
+                    args = ["http://localhost:9291/books/1"]
+                    response = HTTPX.put(url, :json => {"title"=>"Update Book", "author"=>"Update Author"})
                     @output = response.status
                     assert_equal 200, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>"DELETE", :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/books/1", :query=>nil, :Body=>"", :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     response = HTTPX.delete(url)
                     @output = response.status
                     assert_equal 204, @output
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 

--- a/test/newrelic_security/instrumentation-security/net_http/net_http_test.rb
+++ b/test/newrelic_security/instrumentation-security/net_http/net_http_test.rb
@@ -25,7 +25,7 @@ module NewRelic::Security
                     request = Net::HTTP::Get.new(uri.request_uri)
                     response = http.request(request)
                     assert_equal "200", response.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"close"}}]
+                    args = ["http://www.google.com:80/"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -38,7 +38,7 @@ module NewRelic::Security
                     uri = URI(url)
                     @output = Net::HTTP.get(uri)
                     #puts @output
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -53,7 +53,7 @@ module NewRelic::Security
 	                uri.query = URI.encode_www_form(uri_params)
                     @output = Net::HTTP.get_response(uri)
                     assert_equal "200", @output.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com?limit=10&page=3", :path=>"", :query=>"limit=10&page=3", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com?limit=10&page=3"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -70,7 +70,7 @@ module NewRelic::Security
                         @output = http.request(request)
                     end
                     assert_equal "200", @output.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -86,7 +86,7 @@ module NewRelic::Security
                         @output = http.request(request)
                     end
                     assert_equal "200", @output.code
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :URI=>"http://www.google.com", :path=>"", :query=>nil, :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "host"=>"www.google.com"}}]
+                    args = ["http://www.google.com"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
@@ -101,7 +101,7 @@ module NewRelic::Security
                     response = http.request(uri)
                     @output = response.code
                     assert_equal "200", @output
-                    args = [{:Method=>"GET", :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"/", :query=>nil, :URI=>"http://www.google.com:80/", :Body=>nil, :Headers=>{"accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "accept"=>"*/*", "user-agent"=>"Ruby", "connection"=>"keep-alive", "keep-alive"=>"30"}}]
+                    args = ["http://www.google.com:80/"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/patron/patron_test.rb
+++ b/test/newrelic_security/instrumentation-security/patron/patron_test.rb
@@ -19,7 +19,7 @@ module NewRelic::Security
                                             :headers => {'User-Agent' => 'myapp/1.0'} } )
                     @output = sess.get("/").body
                     #puts @output
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com/", :path=>"/", :query=>nil, :Body=>nil, :Headers=>{"Expect"=>""}}]
+                    args = ["https://www.google.com/"]
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType

--- a/test/newrelic_security/instrumentation-security/typhoeus/typhoeus_test.rb
+++ b/test/newrelic_security/instrumentation-security/typhoeus/typhoeus_test.rb
@@ -14,107 +14,87 @@ module NewRelic::Security
 
                 def test_get
                     url = "http://www.google.com?q=test"
-                    args = [{:Method=>:get, :URI=>"http://www.google.com?q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}, :scheme=>"http", :host=>"www.google.com", :port=>80, :path=>"", :query=>"q=test"}]
+                    args = ["http://www.google.com?q=test"]
                     response = Typhoeus.get(url) # input=https://www.google.com
                     assert_equal 200, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_get_ssl
                     url = "https://www.google.com?q=test"
-                    args = [{:Method=>:get, :URI=>"https://www.google.com?q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}, :scheme=>"https", :host=>"www.google.com", :port=>443, :path=>"", :query=>"q=test"}]
+                    args = ["https://www.google.com?q=test"]
                     response = Typhoeus.get(url) # input=https://www.google.com
                     assert_equal 200, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_post_json
                     url = "http://localhost:9291/books"
-                    args = [{:Method=>:post, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books?field1=a%20field", :path=>"/books", :query=>nil, :Body=>"{\"title\":\"New\",\"author\":\"New Author\"}", :Headers=>{:"Content-Type"=>"application/json"}}]
-                    data = {"title"=>"New","author"=>"New Author"}
+                    args = ["http://localhost:9291/books?field1=a%20field"]
+                    data = {"title"=>"New", "author"=>"New Author"}
                     request = Typhoeus::Request.new(
-                        url,
-                        method: :post,
-                        body: data.to_json,
-                        params: { field1: "a field" },
-                        headers: { "Content-Type": "application/json" }
+                      url,
+                      method: :post,
+                      body: data.to_json,
+                      params: { field1: "a field" },
+                      headers: { 'Content-Type': "application/json" }
                     )
                     response = request.run
                     assert_equal 201, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_put_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:put, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1?field1=a%20field", :path=>"/books/1", :query=>nil, :Body=>"{\"title\":\"Update Book\",\"author\":\"Update Author\"}", :Headers=>{:"Content-Type"=>"application/json"}}]
-                    data = {"title"=>"Update Book","author"=>"Update Author"}
+                    args = ["http://localhost:9291/books/1?field1=a%20field"]
+                    data = {"title"=>"Update Book", "author"=>"Update Author"}
                     request = Typhoeus::Request.new(
-                        url,
-                        method: :put,
-                        body: data.to_json,
-                        params: { field1: "a field" },
-                        headers: { "Content-Type": "application/json" }
+                      url,
+                      method: :put,
+                      body: data.to_json,
+                      params: { field1: "a field" },
+                      headers: { 'Content-Type': "application/json" }
                     )
                     response = request.run
                     assert_equal 200, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_equal expected_event.parameters[0][:Body], $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_delete_json
                     url = "http://localhost:9291/books/1"
-                    args = [{:Method=>:delete, :scheme=>"http", :host=>"localhost", :port=>9291, :URI=>"http://localhost:9291/books/1", :path=>"/api/v1/delete/1", :query=>nil, :Body=>nil, :Headers=>{}}]
+                    args = ["http://localhost:9291/books/1"]
                     request = Typhoeus::Request.new(
-                        url,
-                        method: :delete
+                      url,
+                      method: :delete
                     )
                     response = request.run
                     assert_equal 204, response.response_code
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 
                 def test_typhoeus_hydra
                     url = "https://www.google.com?q=test"
-                    args = [{:Method=>:get, :scheme=>"https", :host=>"www.google.com", :port=>443, :URI=>"https://www.google.com?q=test", :path=>"", :query=>"q=test", :Body=>nil, :Headers=>{"User-Agent"=>"Typhoeus - https://github.com/typhoeus/typhoeus", "Expect"=>""}}]
+                    args = ["https://www.google.com?q=test"]
                     hydra = Typhoeus::Hydra.hydra
                     request = Typhoeus::Request.new(url)
                     hydra.queue(request)    
@@ -123,11 +103,7 @@ module NewRelic::Security
                     expected_event = NewRelic::Security::Agent::Control::Event.new(HTTP_REQUEST, args, nil)
                     assert_equal 1, NewRelic::Security::Agent::Control::Collector.get_event_count(HTTP_REQUEST)
                     assert_equal expected_event.caseType, $event_list[0].caseType
-                    assert_equal expected_event.parameters[0][:URI], $event_list[0].parameters[0][:URI]
-                    assert_equal expected_event.parameters[0][:Method], $event_list[0].parameters[0][:Method]
-                    assert_equal expected_event.parameters[0][:scheme], $event_list[0].parameters[0][:scheme]
-                    assert_equal expected_event.parameters[0][:port], $event_list[0].parameters[0][:port]
-                    assert_nil $event_list[0].parameters[0][:Body]
+                    assert_equal expected_event.parameters[0], $event_list[0].parameters[0]
                     assert_nil $event_list[0].eventCategory
                 end
 


### PR DESCRIPTION
## v0.3.0

Version 0.3.0 introduces more control on IAST scanning through new configs(exclude_from_iast_scan, scan_schedule & scan_controllers) and 
features like API inventory for gRPC server and IAST scan start related timestamps.

Updated json_version: **1.2.8**

- Feature: IAST scan exclusion for apis, http request parameters(header, query & body) & IAST detection categories and scan scheduling through delay, duration & cron schedule. [PR#131](https://github.com/newrelic/csec-ruby-agent/pull/131)

- Feature: IAST scan request rate limit to control IAST scan request firing. [PR#132](https://github.com/newrelic/csec-ruby-agent/pull/132)

- Feature: API endpoints support for gRPC server applications. [PR#143](https://github.com/newrelic/csec-ruby-agent/pull/143)

- Feature: Reporting of IAST scanning application procStartTime, trafficStartedTime & scanStartTime. [PR#136](https://github.com/newrelic/csec-ruby-agent/pull/136)

- Misc Chore: Optimised SSRF events parameters to send only URL in parameters. [PR#129](https://github.com/newrelic/csec-ruby-agent/pull/129)

##### New security configs

```yaml
security:
  exclude_from_iast_scan:
    api: []
    http_request_parameters:
      header: []
      query: []
      body: []
    iast_detection_category:
      insecure_settings: false
      invalid_file_access: false
      sql_injection: false
      nosql_injection: false
      ldap_injection: false
      javascript_injection: false
      command_injection: false
      xpath_injection: false
      ssrf: false
      rxss: false
  scan_schedule:
    delay: 0
    duration: 0
    schedule: ""
    always_sample_traces: false
  scan_controllers:
    iast_scan_request_rate_limit: 3600
```

##### Deprecated security configs (will be removed in next major release v1.0.0)
```yaml
security:
  request:
    body_limit: 300
  detection:
    rci:
      enabled: true
    rxss:
      enabled: true
    deserialization:
      enabled: true
```