### PR TITLE
Fixes: Do not send empty url endpoint json & Reconnect in random interval between 5-15 secs

### DIFF
--- a/lib/newrelic_security/agent/control/control_command.rb
+++ b/lib/newrelic_security/agent/control/control_command.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'securerandom'
 
 module NewRelic::Security
   module Agent
@@ -93,7 +94,7 @@ module NewRelic::Security
           NewRelic::Security::Agent.agent.iast_client.completed_requests.clear if NewRelic::Security::Agent.agent.iast_client
           NewRelic::Security::Agent.agent.iast_client.pending_request_ids.clear if NewRelic::Security::Agent.agent.iast_client
           NewRelic::Security::Agent.config.disable_security
-          Thread.new { NewRelic::Security::Agent.agent.reconnect(0) }
+          Thread.new { NewRelic::Security::Agent.agent.reconnect(SecureRandom.random_number(10) + 5) }
         end
 
         def current_time_millis

--- a/lib/newrelic_security/agent/utils/agent_utils.rb
+++ b/lib/newrelic_security/agent/utils/agent_utils.rb
@@ -127,7 +127,7 @@ module NewRelic::Security
             end
           end
         when :roda
-          NewRelic::Security::Agent.logger.warn "TODO: Roda is a routing tree web toolkit, which generates route dynamically, hence route extraction is not possible."
+          NewRelic::Security::Agent.logger.debug "TODO: Roda is a routing tree web toolkit, which generates route dynamically, hence route extraction is not possible."
         when :grpc
           router.owner.superclass.public_instance_methods(false).each do |m|
             NewRelic::Security::Agent.agent.route_map << "*@/#{router.owner}/#{m}"
@@ -137,7 +137,7 @@ module NewRelic::Security
         end
         disable_object_space_in_jruby if NewRelic::Security::Agent.config[:jruby_objectspace_enabled]
         NewRelic::Security::Agent.logger.debug "ALL ROUTES : #{NewRelic::Security::Agent.agent.route_map}"
-        NewRelic::Security::Agent.agent.event_processor&.send_application_url_mappings
+        NewRelic::Security::Agent.agent.event_processor&.send_application_url_mappings unless NewRelic::Security::Agent.agent.route_map.empty?
       rescue Exception => exception
         NewRelic::Security::Agent.logger.error "Error in get app routes : #{exception.inspect} #{exception.backtrace}"
       end


### PR DESCRIPTION
#### Fixes
- Do not send empty url endpoint json (e.g. for Roda & Rack) [NR-344595](https://new-relic.atlassian.net/browse/NR-344595)
- Reconnect in random interval between 5-15 secs [NR-346007](https://new-relic.atlassian.net/browse/NR-346007)

[NR-344595]: https://new-relic.atlassian.net/browse/NR-344595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-346007]: https://new-relic.atlassian.net/browse/NR-346007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ