### PR TITLE
fix for NR-331946

### DIFF
--- a/lib/newrelic_security/agent/control/collector.rb
+++ b/lib/newrelic_security/agent/control/collector.rb
@@ -84,6 +84,7 @@ module NewRelic::Security
         def get_user_frame_index(stk)
           return -1 if NewRelic::Security::Agent.config[:app_root].nil?
           stk.each_with_index do |val, index|
+            next if stk[index + 1] && stk[index + 1].path.start_with?(NewRelic::Security::Agent.config[:app_root])
             return index if val.path.start_with?(NewRelic::Security::Agent.config[:app_root])
           end
           return -1


### PR DESCRIPTION
Fix for Vulnerability is missed in text/json because of small stackTrace [NR-331946](https://new-relic.atlassian.net/browse/NR-331946)

[NR-331946]: https://new-relic.atlassian.net/browse/NR-331946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ